### PR TITLE
fix error dialogs (bootstrap alert-danger)

### DIFF
--- a/djnro/templates/edumanage/add_user.html
+++ b/djnro/templates/edumanage/add_user.html
@@ -6,7 +6,7 @@
 		<label class="control-label" for="id_name"><b>{% trans "Name" %}</b></label>
 		<div class="controls">
 			{{ form.name }}
-			{% if form.name.errors %} <span class="help-inline"> {{ form.name.errors|join:", " }} </span>
+			{% if form.name.errors %} <div class="alert-danger"> {{ form.name.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.name.help_text }}</span>
 		</div>
 		</div>
@@ -14,7 +14,7 @@
 		<label class="control-label" for="id_email"><b>{% trans "Email" %}</b></label>
 		<div class="controls">
 			{{ form.email }}
-			{% if form.email.errors %} <span class="help-inline"> {{ form.email.errors|join:", " }} </span>
+			{% if form.email.errors %} <div class="alert-danger"> {{ form.email.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.email.help_text }}</span>
 		</div>
 		</div>
@@ -22,7 +22,7 @@
 		<label class="control-label" for="id_phone"><b>{% trans "Phone" %}</b></label>
 		<div class="controls">
 			{{ form.phone }}
-			{% if form.phone.errors %} <span class="help-inline"> {{ form.phone.errors|join:", " }} </span>
+			{% if form.phone.errors %} <div class="alert-danger"> {{ form.phone.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.phone.help_text }}</span>
 		</div>
 		</div>

--- a/djnro/templates/edumanage/contacts_edit.html
+++ b/djnro/templates/edumanage/contacts_edit.html
@@ -21,7 +21,7 @@
 		<label class="control-label" for="id_name"><b>{% trans "Name" %}</b></label>
 		<div class="controls">
 			{{ form.name }}
-			{% if form.name.errors %} <span class="help-inline"> {{ form.name.errors|join:", " }} </span>
+			{% if form.name.errors %} <div class="alert-danger"> {{ form.name.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.name.help_text }}</span>
 		</div>
 		</div>
@@ -29,7 +29,7 @@
 		<label class="control-label" for="id_email"><b>{% trans "Email" %}</b></label>
 		<div class="controls">
 			{{ form.email }}
-			{% if form.email.errors %} <span class="help-inline"> {{ form.email.errors|join:", " }} </span>
+			{% if form.email.errors %} <div class="alert-danger"> {{ form.email.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.email.help_text }}</span>
 		</div>
 		</div>
@@ -37,7 +37,7 @@
 		<label class="control-label" for="id_phone"><b>{% trans "Phone" %}</b></label>
 		<div class="controls">
 			{{ form.phone }}
-			{% if form.phone.errors %} <span class="help-inline"> {{ form.phone.errors|join:", " }} </span>
+			{% if form.phone.errors %} <div class="alert-danger"> {{ form.phone.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.phone.help_text }}</span>
 		</div>
 		</div>

--- a/djnro/templates/edumanage/institution_edit.html
+++ b/djnro/templates/edumanage/institution_edit.html
@@ -35,15 +35,15 @@
 				<label class="control-label" for="id_address_street"><b>{% trans "Address Street" %}</b></label>
 				<div class="controls">
 					{{ form.address_street }}
-					{% if form.address_street.errors %} <span class="help-inline"> {{ form.address_street.errors|join:", " }} </span>
+					{% if form.address_street.errors %} <div class="alert-danger" > {{ form.address_street.errors|join:", " }} </div>
 					{% endif %} <span class="help-block"> {{ form.address_street.help_text }}</span>
 				</div>
 			</div>
 			<div class="form-group {% if form.address_city.errors %} error {% endif %}">
 				<label class="control-label" for="id_address_city"><b>{% trans "Address City" %}</b></label>
-				<div class="controls">
+				<div class="controls" >
 					{{ form.address_city }}
-					{% if form.address_city.errors %} <span class="help-inline"> {{ form.address_city.errors|join:", " }} </span>
+					{% if form.address_city.errors %} <div class="alert-danger" > {{ form.address_city.errors|join:", " }} </div>
 					{% endif %} <span class="help-block"> {{ form.address_city.help_text }}</span>
 				</div>
 			</div>
@@ -53,23 +53,23 @@
 					<div class="">{{ form.contact }}</div>
 					<button class="btn btn-small btn-info" id="add_contact"><i class="icon-plus-sign icon-white"></i>Add...</button>
 					{% if form.contact.errors %} <span class="help-inline"> {{ form.ertype.contact|join:", " }} </span>
-					{% endif %} <span class="help-block"> {{ form.contact.help_text }}</span>
+					{% endif %} <span class="help-block"> {{ form.contact.help_text }}</span> 
 				</div>
 			</div>
 		    <div class="form-group {% for err in urls_form.errors %}{% if err|length > 0 %}error{% endif %}{% endfor %}{% if urls_form.non_form_errors %}error{% endif %}">
 		        <label class="control-label" for="id_urls"><b>{% trans "Urls" %}</b></label>
 		        {{urls_form.management_form}}
 		        <div class="controls">
-		        {% if urls_form.non_form_errors %} <span class="help-inline"> {{ urls_form.non_form_errors|join:", "}}</span>{% endif %}
+		        {% if urls_form.non_form_errors %} <div class="alert-danger"> {{ urls_form.non_form_errors|join:", "}}</div>{% endif %}
 		            <table id="urlsform"><thead><tr><td>url</td><td>type</td><td>language</td></tr></thead><tbody>
 		        {% for formset in urls_form.forms %}
 		        {{ formset.id }}
 
 
 		            <tr id="{{ formset.prefix }}-row">
-		            <td> {% if formset.instance.pk %}{{ formset.DELETE }}{% endif %}{{ formset.url }}{% if formset.url.errors %}<br><div class="help-inline"> {{ formset.url.errors|join:", " }} </div>{% endif %}</td>
-		             <td>{{formset.urltype}}{% if formset.urltype.errors %}<br><p class="help-inline"> {{ formset.urltype.errors|join:", " }} </p>{% endif %}</td>
-		             <td>{{formset.lang}}{% if formset.lang.errors %}<br><p class="help-inline"> {{ formset.lang.errors|join:", " }} </p>{% endif %}</td>
+		            <td> {% if formset.instance.pk %}{{ formset.DELETE }}{% endif %}{{ formset.url }}{% if formset.url.errors %}<br><div class="alert-danger">  {{ formset.url.errors|join:", " }} </div>{% endif %}</td>
+		             <td>{{formset.urltype}}{% if formset.urltype.errors %}<br><div class="alert-danger">  {{ formset.urltype.errors|join:", " }} </div>{% endif %}</td>
+		             <td>{{formset.lang}}{% if formset.lang.errors %}<br><div class="alert-danger">  {{ formset.lang.errors|join:", " }} </div>{% endif %}</td>
 
 		        </tr>
 		        {% endfor %}
@@ -79,9 +79,9 @@
 		    {% if institution.ertype == 2 or institution.ertype == 3 %}
 			<div class="form-group {% if form.oper_name.errors %} error {% endif %}">
 				<label class="control-label" for="id_oper_name"><b>{% trans "Domain Name" %}</b></label>
-				<div class="controls">
+				<div class="controls" >
 					{{ form.oper_name }}
-					{% if form.oper_name.errors %} <span class="help-inline"> {{ form.oper_name.errors|join:", " }} </span>
+					{% if form.oper_name.errors %} <div class="alert-danger" >  {{ form.oper_name.errors|join:", " }} </div>
 					{% endif %} <span class="help-block">{% autoescape off %}{{ form.oper_name.help_text }}{% endautoescape %}</span>
 				</div>
 			</div>
@@ -91,7 +91,7 @@
 				<label class="control-label" for="id_number_user">{% trans "Number of Users" %}</label>
 				<div class="controls">
 					{{ form.number_user }}
-					{% if form.number_user.errors %} <span class="help-inline"> {{ form.number_user.errors|join:", " }} </span>
+					{% if form.number_user.errors %} <div class="alert-danger">  {{ form.number_user.errors|join:", " }} </div>
 					{% endif %} <span class="help-block"> {{ form.number_user.help_text }}</span>
 				</div>
 			</div>
@@ -100,7 +100,7 @@
 				<label class="control-label" for="id_number_id">{% trans "Number of IDs" %}</label>
 				<div class="controls">
 					{{ form.number_id }}
-					{% if form.number_id.errors %} <span class="help-inline"> {{ form.number_id.errors|join:", " }} </span>
+					{% if form.number_id.errors %} <div class="alert-danger">  {{ form.number_id.errors|join:", " }} </div>
 					{% endif %} <span class="help-block"> {{ form.number_id.help_text }}</span>
 				</div>
 			</div>

--- a/djnro/templates/edumanage/instrealmmon_edit.html
+++ b/djnro/templates/edumanage/instrealmmon_edit.html
@@ -23,7 +23,7 @@
 		<label class="control-label" for="id_realm"><b>{% trans "Realm" %}</b></label>
 		<div class="controls">
 			{{ form.realm }}
-			{% if form.realm.errors %} <span class="help-inline"> {{ form.realm.errors|join:", " }} </span>
+			{% if form.realm.errors %} <div class="alert-danger"> {{ form.realm.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.realm.help_text }}</span>
 		</div>
 	</div>
@@ -31,7 +31,7 @@
 		<label class="control-label" for="id_mon_type"><b>{% trans "Monitoring Method" %}</b></label>
 		<div class="controls">
 			{{ form.mon_type }}
-			{% if form.mon_type.errors %} <span class="help-inline"> {{ form.mon_type.errors|join:", " }} </span>
+			{% if form.mon_type.errors %} <div class="alert-danger"> {{ form.mon_type.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.mon_type.help_text }}</span>
 		</div>
 	</div>

--- a/djnro/templates/edumanage/monlocauthpar_edit.html
+++ b/djnro/templates/edumanage/monlocauthpar_edit.html
@@ -26,7 +26,7 @@
 		<label class="control-label" for="id_eap_method"><b>{% trans "EAP Method" %}</b></label>
 		<div class="controls">
 			{{ form.eap_method }}
-			{% if form.eap_method.errors %} <span class="help-inline"> {{ form.eap_method.errors|join:", " }} </span>
+			{% if form.eap_method.errors %} <div class="alert-danger"> {{ form.eap_method.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.eap_method.help_text }}</span>
 		</div>
 	</div>
@@ -34,7 +34,7 @@
 		<label class="control-label" for="id_phase2"><b>{% trans "EAP2 Method" %}</b></label>
 		<div class="controls">
 			{{ form.phase2 }}
-			{% if form.phase2.errors %} <span class="help-inline"> {{ form.phase2.errors|join:", " }} </span>
+			{% if form.phase2.errors %} <div class="alert-danger"> {{ form.phase2.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.phase2.help_text }}</span>
 		</div>
 	</div>
@@ -42,7 +42,7 @@
 		<label class="control-label" for="id_username"><b>{% trans "Username" %}</b></label>
 		<div class="controls">
 			{{ form.username }}
-			{% if form.username.errors %} <span class="help-inline"> {{ form.username.errors|join:", " }} </span>
+			{% if form.username.errors %} <div class="alert-danger"> {{ form.username.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.username.help_text }}</span>
 		</div>
 	</div>
@@ -50,7 +50,7 @@
 		<label class="control-label" for="id_passwp"><b>{% trans "Password" %}</b></label>
 		<div class="controls">
 			<input type="password" maxlength="80" name="passwp" id="id_passwp" {% if edit %}value='{{form.instance.passwp}}'{% endif %} {% if form.data.passwp %}value='{{form.data.passwp}}'{% endif %}>
-			{% if form.passwp.errors %} <span class="help-inline"> {{ form.passwp.errors|join:", " }} </span>
+			{% if form.passwp.errors %} <div class="alert-danger"> {{ form.passwp.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.passwp.help_text }}</span>
 		</div>
 	</div>

--- a/djnro/templates/edumanage/realms_edit.html
+++ b/djnro/templates/edumanage/realms_edit.html
@@ -31,7 +31,7 @@
 		<label class="control-label" for="id_realm"><b>{% trans "Realm" %}</b></label>
 		<div class="controls">
 			{{ form.realm }}
-			{% if form.realm.errors %} <span class="help-inline"> {{ form.realm.errors|join:", " }} </span>
+			{% if form.realm.errors %} <div class="alert-danger"> {{ form.realm.errors|join:", " }} </div>
 			{% endif %} <span class="help-block"> {{ form.realm.help_text }}</span>
 		</div>
 	</div>
@@ -39,7 +39,7 @@
 		<label class="control-label" for="id_proxyto"><b>{% trans "Proxy to Servers" %}</b></label>
 		<div class="controls">
 			{{ form.proxyto }}
-			{% if form.proxyto.errors %}<span class="help-inline"> {{ form.proxyto.errors|join:", " }} </span>
+			{% if form.proxyto.errors %} <div class="alert-danger"> {{ form.proxyto.errors|join:", " }} </div>
 			{% endif %}<span class="help-block">{% trans "Only IdP and IdP/SP server types are allowed" %}</span>
 		</div>
 	</div>

--- a/djnro/templates/edumanage/servers_edit.html
+++ b/djnro/templates/edumanage/servers_edit.html
@@ -23,7 +23,7 @@
 			<label class="control-label" for="id_ertype"><b>{% trans "Type" %}</b></label>
 			<div class="controls">
 				{{ form.ertype }}
-				{% if form.ertype.errors %} <span class="help-inline"> {{ form.ertype.errors|join:", " }} </span>
+				{% if form.ertype.errors %} <div class="alert-danger"> {{ form.ertype.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.ertype.help_text }}</span>
 			</div>
 		</div>
@@ -33,7 +33,7 @@
 			<label class="control-label" for="id_addr_type"><b>{% trans "Address Family" %}</b></label>
 			<div class="controls">
 				{{ form.addr_type }}
-				{% if form.addr_type.errors %} <span class="help-inline"> {{ form.addr_type.errors|join:", " }} </span>
+				{% if form.addr_type.errors %} <div class="alert-danger"> {{ form.addr_type.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.addr_type.help_text }}</span>
 			</div>
 		</div>
@@ -43,7 +43,7 @@
 			<label class="control-label" for="id_host"><b>{% trans "Hostname" %}</b></label>
 			<div class="controls">
 				{{ form.host }}
-				{% if form.host.errors %} <span class="help-inline"> {{ form.host.errors|join:", " }} </span>
+				{% if form.host.errors %} <div class="alert-danger"> {{ form.host.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.host.help_text }}</span>
 			</div>
 		</div>
@@ -53,7 +53,7 @@
 			<label class="control-label" for="id_name">{% trans "Label" %}</label>
 			<div class="controls">
 				{{ form.name }}
-				{% if form.name.errors %} <span class="help-inline"> {{ form.name.errors|join:", " }} </span>
+				{% if form.name.errors %} <div class="alert-danger"> {{ form.name.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.name.help_text }}</span>
 			</div>
 		</div>
@@ -64,7 +64,7 @@
 			<label class="control-label" for="id_rad_pkt_type"><b>{% trans "RADIUS Packet Types" %}</b></label>
 			<div class="controls">
 				{{ form.rad_pkt_type }}
-				{% if form.rad_pkt_type.errors %} <span class="help-inline"> {{ form.rad_pkt_type.errors|join:", " }} </span>
+				{% if form.rad_pkt_type.errors %} <div class="alert-danger"> {{ form.rad_pkt_type.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.rad_pkt_type.help_text }}</span>
 			</div>
 		</div>
@@ -74,7 +74,7 @@
 			<label class="control-label" for="id_auth_port"><b>{% trans "Authentication Port" %}</b></label>
 			<div class="controls">
 				{{ form.auth_port }}
-				{% if form.auth_port.errors %} <span class="help-inline"> {{ form.auth_port.errors|join:", " }} </span>
+				{% if form.auth_port.errors %} <div class="alert-danger"> {{ form.auth_port.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.auth_port.help_text }}</span>
 			</div>
 		</div>
@@ -84,7 +84,7 @@
 			<label class="control-label" for="id_acct_port"><b>{% trans "Accounting Port" %}</b></label>
 			<div class="controls">
 				{{ form.acct_port }}
-				{% if form.acct_port.errors %} <span class="help-inline"> {{ form.acct_port.errors|join:", " }} </span>
+				{% if form.acct_port.errors %} <div class="alert-danger"> {{ form.acct_port.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.acct_port.help_text }}</span>
 			</div>
 		</div>
@@ -95,7 +95,7 @@
 			<label class="control-label" for="id_status_server">{% trans "Status-Server" %}</label>
 			<div class="controls">
 				{{ form.status_server }}
-				{% if form.status_server.errors %} <span class="help-inline"> {{ form.status_server.errors|join:", " }} </span>
+				{% if form.status_server.errors %} <div class="alert-danger"> {{ form.status_server.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.status_server.help_text }}</span>
 			</div>
 		</div>
@@ -105,7 +105,7 @@
 			<label class="control-label" for="id_secret"><b>{% trans "Secret" %}</b></label>
 			<div class="controls">
 				<input type="password" maxlength="80" name="secret" id="id_secret" {% if edit %}value='{{form.instance.secret}}'{% endif %} {% if form.data.secret %}value='{{form.data.secret}}'{% endif %}>
-				{% if form.secret.errors %} <span class="help-inline"> {{ form.secret.errors|join:", " }} </span>
+				{% if form.secret.errors %} <div class="alert-danger"> {{ form.secret.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.secret.help_text }}</span>
 			</div>
 		</div>
@@ -115,7 +115,7 @@
 			<label class="control-label" for="id_proto"><b>{% trans "Protocol" %}</b></label>
 			<div class="controls">
 				{{ form.proto }}
-				{% if form.proto.errors %} <span class="help-inline"> {{ form.proto.errors|join:", " }} </span>
+				{% if form.proto.errors %} <div class="alert-danger"> {{ form.proto.errors|join:", " }} </div>
 				{% endif %} <span class="help-block">{{ form.proto.help_text }}</span>
 			</div>
 		</div>

--- a/djnro/templates/edumanage/services_edit.html
+++ b/djnro/templates/edumanage/services_edit.html
@@ -47,9 +47,9 @@
 			 				<button class="btn btn-info" id="myloc">
 			 					{% trans "Current Location" %}
 			 				</button>
-			 				{% if form.longitude.errors %} <span class="help-inline"> {{ form.longitude.errors|join:", " }} </span>
+			 				{% if form.longitude.errors %} <div class="alert-danger"> {{ form.longitude.errors|join:", " }} </div>
 			 				{% endif %}
-			 				{% if form.latitude.errors %} <span class="help-inline"> {{ form.latitude.errors|join:", " }} </span>
+			 				{% if form.latitude.errors %} <div class="alert-danger"> {{ form.latitude.errors|join:", " }} </div>
 			 				{% endif %} <span class="help-block">{{ form.longitude.help_text }}</span>
 			 </div>
 		</div>
@@ -62,14 +62,14 @@
 			{{services_form.management_form}}
 			<div class="controls">
 			{% for err in services_form.errors %}{% if err|length > 0 %}<span class="help-inline"></span>{% endif %}{% endfor %}
-			{% if services_form.non_form_errors %} <span class="help-inline"> {{ services_form.non_form_errors|join:", "}}</span>{% endif %}
+			{% if services_form.non_form_errors %} <div class="alert-danger"> {{ services_form.non_form_errors|join:", "}}</div>{% endif %}
 				<table id="locsform"><thead><tr><td>{% trans "Name" %}</td><td>{% trans "Language" %}</td></tr></thead><tbody>
 			{% for formset_s in services_form.forms %}
 			{{ formset_s.id }}
 
 
 				<tr id="{{ formset_s.prefix }}-row">
-				<td> {% if formset_s.instance.pk %}{{ formset_s.DELETE }}{% endif %}{{ formset_s.name }}{% if formset_s.name.errors %}<br><div class="help-inline"> {{ formset_s.name.errors|join:", " }} </div>{% endif %}</td>
+				<td> {% if formset_s.instance.pk %}{{ formset_s.DELETE }}{% endif %}{{ formset_s.name }}{% if formset_s.name.errors %}<br><div class="alert-danger">{{ formset_s.name.errors|join:", " }} </div>{% endif %}</td>
 		             <td>{{formset_s.lang}}{% if formset_s.lang.errors %}<br><p class="help-inline"> {{ formset_s.lang.errors|join:", " }} </p>{% endif %}</td>
 
 			</tr>
@@ -83,7 +83,7 @@
 			<label for="id_address_street">{% trans "Address Street" %}</label>
 			<div class="controls">
 				{{ form.address_street }}
-				{% if form.address_street.errors %} <span class="help-inline"> {{ form.address_street.errors|join:", " }} </span>
+				{% if form.address_street.errors %} <div class="alert-danger"> {{ form.address_street.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.address_street.help_text }}</span>
 			</div>
 		</div>
@@ -93,7 +93,7 @@
 			<label for="id_address_city"><b>{% trans "Address City" %}</b></label>
 			<div class="controls">
 				{{ form.address_city }}
-				{% if form.address_city.errors %} <span class="help-inline"> {{ form.address_city.errors|join:", " }} </span>
+				{% if form.address_city.errors %} <div class="alert-danger"> {{ form.address_city.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.address_city.help_text }}</span>
 			</div>
 		</div>
@@ -103,7 +103,7 @@
 			<label for="id_url"><b>SSID</b></label>
 			<div class="controls">
 				{{ form.SSID }}
-				{% if form.SSID.errors %} <span class="help-inline"> {{ form.SSID.errors|join:", " }} </span>
+				{% if form.SSID.errors %}<div class="alert-danger"> {{ form.SSID.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.SSID.help_text }}</span>
 			</div>
 		</div>
@@ -113,7 +113,7 @@
 			<label for="id_contact">{% trans "Contacts" %}</label>
 			<div class="controls">
 				{{ form.contact }} <button class="btn btn-small btn-info" id="add_contact"><i class="icon-plus-sign icon-white"></i>Add...</button>
-				{% if form.contact.errors %} <span class="help-inline"> {{ form.contact.errors|join:", " }} </span>
+				{% if form.contact.errors %} <div class="alert-danger"> {{ form.contact.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.contact.help_text }}</span>
 			</div>
 		</div>
@@ -123,7 +123,7 @@
 			<label for="id_oper_name">{% trans "Encryption Level" %}</label>
 			<div class="controls">
 				{{ form.enc_level }}
-				{% if form.enc_level.errors %} <span class="help-inline"> {{ form.enc_level.errors|join:", " }} </span>
+				{% if form.enc_level.errors %} <div class="alert-danger"> {{ form.enc_level.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.enc_level.help_text }}</span>
 			</div>
 		</div>
@@ -133,7 +133,7 @@
 			<label for="id_number_user">{% trans "Port Restrict" %}</label>
 			<div class="controls">
 				{{ form.port_restrict }}
-				{% if form.port_restrict.errors %} <span class="help-inline"> {{ form.port_restrict.errors|join:", " }} </span>
+				{% if form.port_restrict.errors %} <div class="alert-danger"> {{ form.port_restrict.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.port_restrict.help_text }}</span>
 			</div>
 		</div>
@@ -143,7 +143,7 @@
 			<label for="id_number_id">{% trans "Transparent Proxy" %}</label>
 			<div class="controls">
 				{{ form.transp_proxy }}
-				{% if form.transp_proxy.errors %} <span class="help-inline"> {{ form.transp_proxy.errors|join:", " }} </span>
+				{% if form.transp_proxy.errors %} <div class="alert-danger"> {{ form.transp_proxy.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.transp_proxy.help_text }}</span>
 			</div>
 		</div>
@@ -153,7 +153,7 @@
 			<label for="id_number_id">IPv6</label>
 			<div class="controls">
 				{{ form.IPv6 }}
-				{% if form.IPv6.errors %} <span class="help-inline"> {{ form.IPv6.errors|join:", " }} </span>
+				{% if form.IPv6.errors %} <div class="alert-danger"> {{ form.IPv6.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.IPv6.help_text }}</span>
 			</div>
 		</div>
@@ -163,7 +163,7 @@
 			<label for="id_number_id">NAT</label>
 			<div class="controls">
 				{{ form.NAT }}
-				{% if form.NAT.errors %} <span class="help-inline"> {{ form.NAT.errors|join:", " }} </span>
+				{% if form.NAT.errors %} <div class="alert-danger"> {{ form.NAT.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.NAT.help_text }}</span>
 			</div>
 		</div>
@@ -173,7 +173,7 @@
 			<label for="id_number_id"><b>{% trans "AP number" %}</b></label>
 			<div class="controls">
 				{{ form.AP_no }}
-				{% if form.AP_no.errors %} <span class="help-inline"> {{ form.AP_no.errors|join:", " }} </span>
+				{% if form.AP_no.errors %} <div class="alert-danger"> {{ form.AP_no.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.AP_no.help_text }}</span>
 			</div>
 		</div>
@@ -183,7 +183,7 @@
 			<label for="id_number_id">{% trans "Wired" %}</label>
 			<div class="controls">
 				{{ form.wired }}
-				{% if form.wired.errors %} <span class="help-inline"> {{ form.wired.errors|join:", " }} </span>
+				{% if form.wired.errors %} <div class="alert-danger"> {{ form.wired.errors|join:", " }} </div>
 				{% endif %} <span class="help-block"> {{ form.wired.help_text }}</span>
 			</div>
 		</div>
@@ -193,8 +193,8 @@
 			<label for="id_urls">{% trans "Urls" %}</label>
 			{{urls_form.management_form}}
 			<div class="controls">
-			{% for err in urls_form.errors %}{% if err|length > 0 %}<span class="help-inline">{{err}}</span>{% endif %}{% endfor %}
-			{% if urls_form.non_form_errors %} <span class="help-inline"> {{ urls_form.non_form_errors|join:", "}}</span>{% endif %}
+			{% for err in urls_form.errors %}{% if err|length > 0 %}<div class="alert-danger">{{err}}</div>{% endif %}{% endfor %}
+			{% if urls_form.non_form_errors %} <div class="alert-danger"> {{ urls_form.non_form_errors|join:", "}}</div>{% endif %}
 				<table id="urlsform">
 					<thead>
 						<tr>
@@ -208,7 +208,7 @@
 						{{ formset.id }}
 						<tr id="{{ formset.prefix }}-row">
 							<td>
-								{% if formset.instance.pk %}{{ formset.DELETE }}{% endif %}{{ formset.url }}{% if formset.url.errors %}<br><div class="help-inline"> {{ formset.url.errors|join:", " }} </div>{% endif %}
+								{% if formset.instance.pk %}{{ formset.DELETE }}{% endif %}{{ formset.url }}{% if formset.url.errors %}<br><div class="alert-danger"> {{ formset.url.errors|join:", " }} </div>{% endif %}
 							</td>
 		             		<td>
 		             			{{formset.urltype}}{% if formset.urltype.errors %}<br><p class="help-inline"> {{ formset.urltype.errors|join:", " }} </p>{% endif %}


### PR DESCRIPTION
Error descriptions in edit forms have been fixed (from `html <span >` to  `html <div class = "alert-danger">`

Now they appear red & highlighted as seen below
![screenshot from 2015-09-12 14 07 07](https://cloud.githubusercontent.com/assets/14074326/9831253/a0c3906e-5957-11e5-9f0a-78d9ad853397.png)
