### PR TITLE
Update requirements.txt to Django 1.4.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.4.5
+Django==1.4.22
 South==1.0
 argparse>=1.2.1
 django-registration==1.0


### PR DESCRIPTION
Hi there,

I had been running into issues with running DjNRO in the English locale - exceptions caused by:

```
AttributeError: 'NoneType' object has no attribute 'has_header'
```

Django 1.4.22 (latest in the 1.4 branch) fixes these issues.

Would you be happy to merge this in?

Note that as of October 1st, 2015, Django 1.4 is EOL - so might I ask what are your plans regarding migration to 1.8 - if any?

Cheers,
Vlad
## 

Vladimir Mencl
Senior Software Engineer

Research & Education 
Advanced Network NZ Ltd

P +64 3 364 3012
M +64 21 997352
E  vladimir.mencl@reannz.co.nz
www.reannz.co.nz
