### PR TITLE
Requirements: ask for latest Django 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.4
+Django>=1.4,<1.5
 South==1.0
 argparse>=1.2.1
 django-registration==1.0


### PR DESCRIPTION
In 37d1c01 / #3, I fixed a Django issue by updating the Django requirement to 1.4.22

Later, 0a077ebc was I assume aiming to generalize this by pointing to "latest
1.4", but unfortunately, points to 1.4(.0) instead.

Fix requirements again, this time explictly asking for:

 Django>=1.4,<1.5
