### PR TITLE
Allow AltLogin to redirect to target URLs

### DIFF
--- a/djnro/templates/overview/login.html
+++ b/djnro/templates/overview/login.html
@@ -37,7 +37,11 @@
 							<div class="form-group">
 								<div class="controls">
 									<button type="submit" class="btn">Sign in</button>
+                                                                        {% if next %}
+									<input type="hidden" name="next" value="{{ next }}" />
+                                                                        {% else %}
 									<input type="hidden" name="next" value="{% url overview %}" />
+                                                                        {% endif %}
 								</div>
 							</div>
 						</form>


### PR DESCRIPTION
Allow using `/altlogin` (local user accounts) with a ``?next` parameter.

This aims to support deployments where no SAML federation exists yet and the NRO would prefer not to depend on social login.  With this change, it is possible to use `/altlogin?next=/manage` as a login URL for Institutional Administrators.

Implementation-wise, in `djnro/templates/overview/login.html`, when a "next" parameter exists in the context, reuse it for the redirect - instead of forcing redirect to `/overview`.
