### PR TITLE
South migrations: improve #4 PostgreSQL workaround

### DIFF
--- a/edumanage/migrations/0022_auto__chg_field_institutiondetails_number_id__del_field_instrealmmon_i.py
+++ b/edumanage/migrations/0022_auto__chg_field_institutiondetails_number_id__del_field_instrealmmon_i.py
@@ -30,7 +30,10 @@ class Migration(SchemaMigration):
         # * http://codeinthehole.com/writing/altering-postgres-table-columns-with-south/
         # * http://stackoverflow.com/questions/13170570/change-type-of-varchar-field-to-integer-cannot-be-cast-automatically-to-type-i
         if ( db._get_connection().vendor == "postgresql" ):
-            db.execute('ALTER TABLE "edumanage_instrealmmon" ALTER COLUMN "realm_id" TYPE integer USING (trim(realm_id)::integer), ALTER COLUMN "realm_id" SET NOT NULL, ALTER COLUMN "realm_id" DROP DEFAULT;')
+            db.execute('ALTER TABLE "edumanage_instrealmmon" ALTER COLUMN "realm_id" TYPE integer USING (trim(realm_id)::integer),'
+                    ' ALTER COLUMN "realm_id" SET NOT NULL,'
+                    ' ALTER COLUMN "realm_id" DROP DEFAULT,'
+                    ' ADD CONSTRAINT "edumanage_i_realm_id_24cc89d4be4145e5_fk_edumanage_instrealm_id" FOREIGN KEY (realm_id) REFERENCES edumanage_instrealm(id) DEFERRABLE INITIALLY DEFERRED;')
         else:
             db.alter_column('edumanage_instrealmmon', 'realm_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['edumanage.InstRealm']))
 


### PR DESCRIPTION
The original fix to the PostgreSQL issue with south migration 0022 did correctly change the field type, but did not add the Foreign Key constraint.

Improve the workaround 9a2924d by also adding the foreign key constraint.

For databases created with the original workaround, the foreign key constraint can be added manually with:

```
ALTER TABLE edumanage_instrealmmon ADD CONSTRAINT "edumanage_i_realm_id_24cc89d4be4145e5_fk_edumanage_instrealm_id" FOREIGN KEY (realm_id) REFERENCES edumanage_instrealm(id) DEFERRABLE INITIALLY DEFERRED;
```

Note that not having the constraint in does not directly break anything, but
could lead to corrupt databases and the database structure is reported
differently with:

```
./manage.py inspectdb
```
