### PR TITLE
InstServer M2M: fix instid handling in server edit

### DIFF
--- a/edumanage/forms.py
+++ b/edumanage/forms.py
@@ -62,12 +62,13 @@ class InstServerForm(forms.ModelForm):
 
     class Meta:
         model = InstServer
+        exclude = ['instid']
 
     def clean_ertype(self):
         ertype = self.cleaned_data['ertype']
 	if not ertype:
 	    raise forms.ValidationError('This field is required.')
-        for institution in self.cleaned_data['instid']:
+        for institution in self.inst_list:
 	    inst_type = institution.ertype
 	    type_list = [inst_type]
 	    if inst_type == 3:

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -562,10 +562,6 @@ def add_server(request, server_pk):
                     'You have no rights to edit this server'
                 )
                 return HttpResponseRedirect(reverse("servers"))
-        form.fields['instid'] = forms.ModelChoiceField(
-            queryset=Institution.objects.filter(pk=inst.pk),
-            empty_label=None
-        )
         if server:
             edit = True
 
@@ -582,8 +578,10 @@ def add_server(request, server_pk):
         try:
             server = InstServer.objects.get(instid=inst, pk=server_pk)
             form = InstServerForm(request_data, instance=server)
+            form.inst_list = server.instid.all()
         except InstServer.DoesNotExist:
             form = InstServerForm(request_data)
+            form.inst_list = [inst]
             if server_pk:
                 messages.add_message(
                     request,
@@ -594,12 +592,9 @@ def add_server(request, server_pk):
 
         if form.is_valid():
             form.save()
+            if not inst in form.instance.instid.all():
+                form.instance.instid.add(inst)
             return HttpResponseRedirect(reverse("servers"))
-        else:
-            form.fields['instid'] = forms.ModelChoiceField(
-                queryset=Institution.objects.filter(pk=inst.pk),
-                empty_label=None
-            )
         if server:
             edit = True
         return render_to_response(


### PR DESCRIPTION
Fix issue: editing and saving an InstServer by an inst admin drops all other Inst associations

Fix: remove field['instid'] overrides

Subsequent issue: this allows arbitrary edits of the list of institutions IF
the user changes the display:none style in browser.

Fix: exclude ['instid'] from the form

Subsequent issue: this breaks validation relying on instid

Attempted fix: access instid from model instance, not from cleaned_data: self.instance.instid.all()
Reason for not using this fix: breaks on creating a new server:

```
ValueError: "<InstServer: Server: , Type: None>" needs to have a value for field "instserver" before this many-to-many relationship can be used.
```

Alternate fix: hint the list of institutions to the ModelForm out-of-band (via inst_list attribute)

Additional fix: add the institution to the InstServer AFTER saving.
