### PR TITLE
 Branding: make NRO inst name configurable 

### DIFF
--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -119,6 +119,8 @@ NRO_COUNTRY_NAME = _('My Country')
 NRO_COUNTRY_CODE = 'tld'
 # main domain url used in right top icon, eg. http://www.grnet.gr
 NRO_DOMAIN_MAIN_URL = "http://www.example.com"
+# NRO federation name
+NRO_FEDERATION_NAME = "GRNET AAI federation"
 # developer info for footer
 NRO_PROV_BY_DICT = {"name": "GRNET NOC", "url": "//noc.grnet.gr"}
 #provider social media contact (Use: // to preserve https)

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -113,9 +113,7 @@ TIME_ZONE = 'Europe/Athens'
 # map center (lat, lng)
 MAP_CENTER = (36.97, 23.71)
 
-# Frontend country specific vars, eg. Greece
-NRO_COUNTRY_NAME = _('My Country')
-# Variable used by context_processor to display the "eduroam | <country_code>" in base.html
+# Variable used to determine the active Realm object (in views and context processor)
 NRO_COUNTRY_CODE = 'tld'
 # main domain url used in right top icon, eg. http://www.grnet.gr
 NRO_DOMAIN_MAIN_URL = "http://www.example.com"

--- a/djnro/templates/front/management.html
+++ b/djnro/templates/front/management.html
@@ -17,7 +17,7 @@
     <h5>AAI Federation</h5>
     <hr>
     <p>{% blocktrans %}Authentication and authorization are carried out through a{% endblocktrans %} <a href="http://shibboleth.net/products/service-provider.html">Shibboleth SP</a>.</p>
-    <p>{% blocktrans %}The following attributes are required for administrators and must be released by their home IdPs to the SP{% endblocktrans %} {% trans "according to the" %} <a href="http://aai.grnet.gr/documentation">{% trans "policy and procedures documentation" %}</a> {% trans "provided by the GRNET AAI federation" %}:
+    <p>{% blocktrans %}The following attributes are required for administrators and must be released by their home IdPs to the SP{% endblocktrans %} {% trans "according to the" %} <a href="http://aai.grnet.gr/documentation">{% trans "policy and procedures documentation" %}</a> {% trans "provided by the" %} {{ FEDERATION_NAME }}:
         <table class="table table-bordered">
             <thead><tr><th>{% trans "Attribute" %}</th><th>{% trans "Description" %}</th></tr></thead>
             <tbody>

--- a/edumanage/context_processors.py
+++ b/edumanage/context_processors.py
@@ -1,11 +1,13 @@
 from django.conf import settings
+from edumanage.models import Realm
 
 
 def country_code(context):
     # return the value you want as a dictionnary. you may add multiple values in there.
     return {
-        'COUNTRY_NAME': settings.NRO_COUNTRY_NAME,
         'COUNTRY_CODE': settings.NRO_COUNTRY_CODE,
+        'COUNTRY_NAME': dict(settings.REALM_COUNTRIES)[settings.NRO_COUNTRY_CODE],
+        'NRO_REALM': Realm.objects.get(country=settings.NRO_COUNTRY_CODE),
         'DOMAIN_MAIN_URL': settings.NRO_DOMAIN_MAIN_URL,
         'FEDERATION_NAME': settings.NRO_FEDERATION_NAME,
         'DOMAIN_HELPDESK_DICT': settings.NRO_DOMAIN_HELPDESK_DICT,

--- a/edumanage/context_processors.py
+++ b/edumanage/context_processors.py
@@ -7,6 +7,7 @@ def country_code(context):
         'COUNTRY_NAME': settings.NRO_COUNTRY_NAME,
         'COUNTRY_CODE': settings.NRO_COUNTRY_CODE,
         'DOMAIN_MAIN_URL': settings.NRO_DOMAIN_MAIN_URL,
+        'FEDERATION_NAME': settings.NRO_FEDERATION_NAME,
         'DOMAIN_HELPDESK_DICT': settings.NRO_DOMAIN_HELPDESK_DICT,
         'MAP_CENTER': settings.MAP_CENTER,
         'PROV_TEAM': settings.NRO_PROV_BY_DICT,

--- a/edumanage/decorators.py
+++ b/edumanage/decorators.py
@@ -8,6 +8,9 @@ from accounts.models import UserProfile
 from edumanage.forms import UserProfileForm
 from edumanage.models import Institution
 
+# We only need get_nro_name from edumanage.views, but cannot import selectively
+# as that would fail as a circular dependency
+import edumanage.views
 
 def social_active_required(function):
     def wrap(request, *args, **kw):
@@ -17,7 +20,7 @@ def social_active_required(function):
             if profile.is_social_active is True:
                 return function(request, *args, **kw)
             else:
-                status = _("User account <strong>%s</strong> is pending activation. Administrators have been notified and will activate this account within the next days. <br>If this account has remained inactive for a long time contact your technical coordinator or GRNET Helpdesk") %user.username
+                status = _("User account <strong>%s</strong> is pending activation. Administrators have been notified and will activate this account within the next days. <br>If this account has remained inactive for a long time contact your technical coordinator or %s Helpdesk") % ( user.username, edumanage.views.get_nro_name(request.LANGUAGE_CODE))
                 return render(
                     request,
                     'status.html',

--- a/edumanage/models.py
+++ b/edumanage/models.py
@@ -535,6 +535,17 @@ class Realm(models.Model):
             'country': self.country,
         }
 
+    def get_name(self, lang=None):
+        name = ', '.join([i.name for i in self.org_name.all()])
+        if not lang:
+            return name
+        else:
+            try:
+                name = self.org_name.get(lang=lang)
+                return name
+            except Exception:
+                return name
+
 
 # TODO: this represents a *database view* "realm_data", find a better way to write it
 class RealmData(models.Model):

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1624,7 +1624,9 @@ def user_login(request):
                     " Administrators have been notified and will activate"
                     " this account within the next days. <br>If this account"
                     " has remained inactive for a long time contact your "
-                    "technical coordinator or GRNET Helpdesk") % user.username
+                    "technical coordinator or %s Helpdesk") % (user.username,
+                                                               get_nro_name(request.LANGUAGE_CODE))
+
                 return render_to_response(
                     'status.html',
                     {'status': status, 'inactive': True},
@@ -1724,7 +1726,8 @@ def selectinst(request):
                 " Administrators have been notified and will activate "
                 "this account within the next days. <br>If this account"
                 " has remained inactive for a long time contact your technical"
-                " coordinator or GRNET Helpdesk") % userprofile.user.username
+                " coordinator or %s Helpdesk") % (userprofile.user.username,
+                                                  get_nro_name(request.LANGUAGE_CODE))
             return render_to_response(
                 'status.html',
                 {'status': error, 'inactive': True},
@@ -2343,3 +2346,8 @@ def lookupShibAttr(attrmap, requestMeta):
             if len(requestMeta[attr]) > 0:
                 return requestMeta[attr]
     return ''
+
+def get_nro_name(lang):
+    return Realm.objects.\
+        get(country=settings.NRO_COUNTRY_CODE).\
+        get_name(lang=lang)


### PR DESCRIPTION
There had been a few places where a message displayed to end users would have the name GRNET hard-coded.

Make this configurable - add new setting

NRO_INST_NAME (defaulting to "GRNET")

and also

NRO_FEDERATION_NAME (defaulting to "GRNET AAI federation") to allow having a separate name for the federation.
