### PR TITLE
DjNRO "next" misc fixes

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -77,12 +77,12 @@ Set your cache backend (if you want to use one). For production instances you ca
 
 NRO specific parameters. These affect HTML templates::
 
-	# Frontend country specific vars, eg. Greece
-	NRO_COUNTRY_NAME = _('My Country')
-	# Variable used by context_processor to display the "eduroam | <country_code>" in base.html
+	# Variable used to determine the active Realm object (in views and context processor)
 	NRO_COUNTRY_CODE = 'gr'
 	# main domain url used in right top icon, eg. http://www.grnet.gr
 	NRO_DOMAIN_MAIN_URL = "http://www.example.com"
+	# NRO federation name
+	NRO_FEDERATION_NAME = "GRNET AAI federation"
 	# provider info for footer
 	NRO_PROV_BY_DICT = {"name": "EXAMPLE DEV TEAM", "url": "http://devteam.example.com"}
 	#NRO social media contact (Use: // to preserve https)
@@ -102,6 +102,19 @@ Set the Realm country for REALM model::
 	REALM_COUNTRIES = (
 	             ('country_2letters', 'Country' ),
 	            )
+
+Please note that `REALM_COUNTRIES` must contain an entry where the country code matches the value set in `NRO_COUNTRY_CODE`.  (And, `NRO_COUNTRY_CODE` must also match the `country` value in the `Realm` object created later).
+
+Optionally, configure also the login methods that should be available for institutional administrators to log in.
+
+These are configured in the `MANAGE_LOGIN_METHODS` tuple - which contains a dictionary for each login method.  The default value `local_settings.py.dist` comes prepopulated with a list of popular social login providers supported by `python-social-auth`, plus the `shibboleth` and `locallogin` backends.  For each login method, the following fields are available:
+* `backend`: the name of the backend in python-social-auth (or the special value of `shibboleth` or `locallogin`)
+* `enabled`: whether this login method is enabled
+* `class`: Backend class to load.  Gets added to `settings.AUTHENTICATION_BACKENDS` automatically for enabled login methods.
+* `name`: Human readable name of the authentiation method to present to users
+* `local_image`: Relative path of a local static image to use as logo for the login method.
+* `image_url`: Full URL of an image to use as logo for the login method.
+* `fa_style`: Font-Awesome style to use as logo for the login method.
 
 ### Custom content in footer
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -250,7 +250,7 @@ A Django management command, named fetch_kml, fetches the KML document and updat
 In order to start using DjNRO you need to create a Realm record for your NRO along with one or more contacts linked to it. You can visit the Django admin interface `https://<hostname>/admin` and add a Realm (remember to set REALM_COUNTRIES in local_settings.py).
 In DjNRO the NRO sets the environment for the institution eduroam admins. Therefore the NRO has to insert the initial data for his/her clients/institutions in the *Institutions* Model, again using the Django admin interface. As an alternative, you can copy your existing `institution.xml` to `/path/to/djnro` and run the following to import institution data::
 
-		./manage.py parse_instituion_xml
+		./manage.py parse_institution_xml
 
 ## Exporting Data
 DjNRO can export data in formats suitable for use by other software.

--- a/edumanage/context_processors.py
+++ b/edumanage/context_processors.py
@@ -7,7 +7,6 @@ def country_code(context):
     return {
         'COUNTRY_CODE': settings.NRO_COUNTRY_CODE,
         'COUNTRY_NAME': dict(settings.REALM_COUNTRIES)[settings.NRO_COUNTRY_CODE],
-        'NRO_REALM': Realm.objects.get(country=settings.NRO_COUNTRY_CODE),
         'DOMAIN_MAIN_URL': settings.NRO_DOMAIN_MAIN_URL,
         'FEDERATION_NAME': settings.NRO_FEDERATION_NAME,
         'DOMAIN_HELPDESK_DICT': settings.NRO_DOMAIN_HELPDESK_DICT,

--- a/edumanage/management/commands/parse_institution_xml.py
+++ b/edumanage/management/commands/parse_institution_xml.py
@@ -19,6 +19,7 @@
 # ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
 from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
 from edumanage.models import *
 from xml.etree import ElementTree
 import sys
@@ -48,7 +49,7 @@ class Command(BaseCommand):
 
     def parse_and_create(self, instxmlfile, write):
         doc = ElementTree.parse(instxmlfile)
-        realmid = Realm.objects.get(pk=1)
+        realmid = Realm.objects.get(country=settings.NRO_COUNTRY_CODE)
         root = doc.getroot()
         institutions = []
         institutions = root.getchildren()

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1520,6 +1520,13 @@ def get_all_services(request):
             ).name
         except Name_i18n.DoesNotExist:
             try:
+                response_location['inst'] = sl.institutionid.org_name.get(lang='en').name
+            except Name_i18n.DoesNotExist:
+                response_location['inst'] = 'unknown'
+        try:
+            response_location['name'] = sl.loc_name.get(lang=lang).name
+        except Name_i18n.DoesNotExist:
+            try:
                 response_location['name'] = sl.loc_name.get(lang='en').name
             except Name_i18n.DoesNotExist:
                 response_location['name'] = 'unknown'


### PR DESCRIPTION
In the parse_institution_xml management command, use settings.NRO_COUNTRY_CODE
instead of hard-coded pk=1.  Otherwise, the management command fails when the
primary key of the Realm object is not one.  (E.g., if the object was deleted
and re-created).

The value settings.NRO_COUNTRY_CODE is already used as a key into the Realm
model in edumanage/views.py in get_nro_name.

See also discussion in #18.
