### PR TITLE
Fix requirements.txt (again)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.8.11,<1.9
+Django>=1.8.11,<1.9a
 argparse>=1.2.1
 django-registration==2.0.4
 django-tinymce==1.5.3
@@ -7,4 +7,4 @@ python-social-auth==0.2.14
 requests==2.7.0
 wsgiref==0.1.2
 lxml>=2.3.2
-PyYAML>=3.11,<4
+PyYAML>=3.10,<4.0a


### PR DESCRIPTION
- No need to bump PyYAML min. version to 3.11 (Debian Wheezy provides 3.10
  and that should still work).
- The less than next "release" notation for max. version has the unfortunate
  side effect that a pre-release version apparently passes this spec. So fix
  the spec for Django to ensure that pip will not install anything later than
  1.8.x.

```
  >>> from pkg_resources import parse_version
  >>> parse_version('1.9c1') < parse_version('1.9')
  True
```

  While:

```
  >>> parse_version('1.9c1') < parse_version('1.9a')
  False
```

  See:
  http://stackoverflow.com/questions/11887762/compare-version-strings/21065570#21065570
  https://setuptools.readthedocs.io/en/latest/setuptools.html#specifying-your-project-s-version
