### PR TITLE
Fix branding

### DIFF
--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -122,8 +122,8 @@ NRO_DOMAIN_MAIN_URL = "http://www.example.com"
 NRO_PROV_BY_DICT = {"name": "EXAMPLE NRO TEAM", "url": "http://noc.example.com"}
 # social media contact (Use: // to preserve https)
 NRO_PROV_SOCIAL_MEDIA_CONTACT = [
-    {"url": "//facebook.com/example.com", "icon":"/static/img/facebook_img.png", "name":"Facebook"},
-    {"url": "//twitter.com/example_com", "icon":"/static/img/twitter_img.png", "name":"Twitter"},
+    {"url": "//facebook.com/example.com", "fa_style":"fa-facebook", "name":"Facebook"},
+    {"url": "//twitter.com/example_com", "fa_style":"fa-twitter", "name":"Twitter"},
 ]
 
 # Helpdesk, used in base.html:

--- a/djnro/templates/partial/footer.html
+++ b/djnro/templates/partial/footer.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load template_maybe %}
+{% load staticfiles %}
 
 <footer class="stickyfooter">
     <div>
@@ -7,13 +8,22 @@
             {% if user.is_authenticated %}
                 {% trans "If you have any questions or need help, contact" %} {{ BRANDING.helpdesk.name }} (<a href="{{ BRANDING.helpdesk.uri}}">{{BRANDING.helpdesk.uri}}</a>) - {{BRANDING.helpdesk.phone}}</br>
             {% endif %}
-            {% trans "This is a service provided by" %} <a href="{{ BRANDING.service_provided_by.url}}" target="_blank">{{BRANDING.service_provided_by.name}}</a>
+            {% trans "This is a service provided by" %} <a href="{{ BRANDING.service_provider.url}}" target="_blank">{{BRANDING.service_provider.name}}</a>
             {% for media in BRANDING.social_media %}
                 <a href="{{media.url}}" target="_blank">
-                    <i class="{{media.icon}}"></i>
+		{% if media.local_image %}
+                    <img src="{% static media.local_image %}" style="padding: 0px;">
+                {% comment "backwards compatibility: local_image == icon" %}{% endcomment %}
+                {% elif media.icon %}
+                    <img src="{% static media.icon %}" style="padding: 0px;">
+		{% elif media.image_url %}
+                    <img src="{{ media.image_url }}" style="padding: 0px;">
+		{% elif media.fa_style %}
+                    <i class="fa {{ media.fa_style }}"></i>
+		{% endif %}
                 </a>
             {% endfor %}
-            Powered by <a href="http://djnro.grnet.gr/" target="_blank">DjNRO</a> v{{VERSION}}
+            <br>Powered by <a href="http://djnro.grnet.gr/" target="_blank">DjNRO</a> v{{VERSION}}
             {% if "partial/extra.footer.html"|template_exists %}
             <div class="">
                 {% include_maybe "partial/extra.footer.html" %}

--- a/edumanage/context_processors.py
+++ b/edumanage/context_processors.py
@@ -7,10 +7,12 @@ def country_code(context):
         'COUNTRY_NAME': settings.NRO_COUNTRY_NAME,
         'COUNTRY_CODE': settings.NRO_COUNTRY_CODE,
         'DOMAIN_MAIN_URL': settings.NRO_DOMAIN_MAIN_URL,
-        'DOMAIN_HELPDESK_DICT': settings.NRO_DOMAIN_HELPDESK_DICT,
+        'BRANDING': {
+            'helpdesk': settings.NRO_DOMAIN_HELPDESK_DICT,
+            'social_media': settings.NRO_PROV_SOCIAL_MEDIA_CONTACT,
+            'service_provider': settings.NRO_PROV_BY_DICT,
+        },
         'MAP_CENTER': settings.MAP_CENTER,
-        'PROV_TEAM': settings.NRO_PROV_BY_DICT,
-        'SOCIAL_MEDIA_LIST': settings.NRO_PROV_SOCIAL_MEDIA_CONTACT,
         'VERSION': settings.SW_VERSION
     }
 


### PR DESCRIPTION
- Merge relevant keys in a BRANDING (sub)dict
- Don't rename the context processor more appropriately _yet_
- Allow styling similar to MANAGE_LOGIN_METHODS (local_image, image_url
  or fa_style, but keep the older option icon for backwards compatibility)

Fixes #21 
