### PR TITLE
AllServicePoints: fix MultipleObjectsReturned error

### DIFF
--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1525,22 +1525,8 @@ def get_all_services(request):
         else:
             response_location['enc'] = u"-"
         response_location['AP_no'] = u"%s" % (sl.AP_no)
-        try:
-            response_location['inst'] = sl.institutionid.org_name.get(
-                lang=lang
-            ).name
-        except Name_i18n.DoesNotExist:
-            try:
-                response_location['inst'] = sl.institutionid.org_name.get(lang='en').name
-            except Name_i18n.DoesNotExist:
-                response_location['inst'] = 'unknown'
-        try:
-            response_location['name'] = sl.loc_name.get(lang=lang).name
-        except Name_i18n.DoesNotExist:
-            try:
-                response_location['name'] = sl.loc_name.get(lang='en').name
-            except Name_i18n.DoesNotExist:
-                response_location['name'] = 'unknown'
+        response_location['inst'] = get_i18n_name(sl.institutionid.org_name, lang, 'en', 'unknown')
+        response_location['name'] = get_i18n_name(sl.loc_name, lang, 'en', 'uknown')
         response_location['port_restrict'] = u"%s" % (sl.port_restrict)
         response_location['transp_proxy'] = u"%s" % (sl.transp_proxy)
         response_location['IPv6'] = u"%s" % (sl.IPv6)
@@ -2359,3 +2345,13 @@ def lookupShibAttr(attrmap, requestMeta):
             if len(requestMeta[attr]) > 0:
                 return requestMeta[attr]
     return ''
+
+def get_i18n_name(i18n_name, lang, default_lang='en', default_name='unknown'):
+    names = i18n_name.filter(lang=lang)
+    if names.count()==0:
+        names = i18n_name.filter(lang=default_lang)
+    if names.count()==0:
+        return default_name
+    else:
+        # follow ServiceLoc.get_name()
+        return ', '.join([i.name for i in names])


### PR DESCRIPTION
Hi Zenon,

I had received an error report from Johann, which translated to my fix that you ported to `master` as 3a60a4c breaking when with unhandled exception MultipleObjectsReturned
when there are multiple names (for either Institution or Service Location) with
the selected language.

And, this is permitted in the model, and we have users who create such DB state.

Fix this by using filter(lang=...) instead of get(lang=...)

And wrap the handling this for both org_name and loc_name in a single generic
function - taking a
django.contrib.contenttypes.fields.GenericRelatedObjectManager reference,
language, default_language and default_value.

This also removes the exception handling clutter from get_all_services().

Cheers,
Vlad
