### PR TITLE
Fix broken language selection for non-https

### DIFF
--- a/djnro/templates/base.html
+++ b/djnro/templates/base.html
@@ -40,7 +40,7 @@
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{% trans "Language" %}: {% for lang in LANGUAGES %}{% ifequal LANGUAGE_CODE lang.0 %}{% trans lang.1 %}{% endifequal %}{% endfor %} <span class="caret"></span></a>
                   <ul class="dropdown-menu">
-                    <form action="{% url 'django.views.i18n.set_language' %}" method="post" id="langform">
+                    <form action="{% url 'edumanage.views.set_language' %}" method="post" id="langform">
                         {% csrf_token %}
                         <input name="next" type="hidden" value="{{ next }}" />
                         <input id="langsel" name="language" type="hidden" value="" />

--- a/djnro/urls.py
+++ b/djnro/urls.py
@@ -7,7 +7,7 @@ admin.autodiscover()
 urlpatterns = patterns(
     '',
     (r'^accounts/', include('social.apps.django_app.urls', namespace='social')),
-    (r'^setlang/?$', 'django.views.i18n.set_language'),
+    (r'^setlang/?$', 'edumanage.views.set_language'),
     (r'^admin/', include(admin.site.urls)),
     url(r'^managelogin/(?P<backend>[^/]+)/$', 'edumanage.views.manage_login', name='manage_login'),
     url(r'^login/?', 'edumanage.views.user_login', name="login"),

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -67,6 +67,41 @@ from edumanage.decorators import social_active_required
 from utils.cat_helper import CatQuery
 
 
+# Almost verbatim copy of django.views.i18n.set_language; however:
+# * we avoid creating sessions for anonymous users
+# * we want language selection to work even for requests that are not https;
+#   for session storage this breaks when SESSION_COOKIE_SECURE=True, so we
+#   always set a language cookie too
+def set_language(request):
+    """
+    Redirect to a given url while setting the chosen language in the
+    session and cookie. The session is written only for authenticated users.
+    The url and the language code need to be specified in the request parameters.
+
+    Since this view changes how the user will see the rest of the site, it must
+    only be accessed as a POST request. If called as a GET request, it will
+    redirect to the page in the request (the 'next' parameter) without changing
+    any state.
+    """
+    from django.views import i18n
+    next = request.POST.get('next', request.GET.get('next'))
+    if not i18n.is_safe_url(url=next, host=request.get_host()):
+        next = request.META.get('HTTP_REFERER')
+        if not i18n.is_safe_url(url=next, host=request.get_host()):
+            next = '/'
+    response = HttpResponseRedirect(next)
+    if request.method == 'POST':
+        lang_code = request.POST.get('language', None)
+        if lang_code and i18n.check_for_language(lang_code):
+            if hasattr(request, 'session') and request.user.is_authenticated():
+                request.session[i18n.LANGUAGE_SESSION_KEY] = lang_code
+            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, lang_code,
+                                max_age=settings.LANGUAGE_COOKIE_AGE,
+                                path=settings.LANGUAGE_COOKIE_PATH,
+                                domain=settings.LANGUAGE_COOKIE_DOMAIN)
+    return response
+
+
 @never_cache
 def index(request):
     return render(


### PR DESCRIPTION
Override django.views.i18n.set_language() to fix broken language selection via session storage for non-https when SESSION_COOKIE_SECURE=True