### PR TITLE
TinyMCE fixes

### DIFF
--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -256,11 +256,14 @@ EDUROAM_KML_URL = 'http://monitor.eduroam.org/kml/all.kml'
 # Request session cookies to be marked as secure
 SESSION_COOKIE_SECURE = True
 
+TINYMCE_COMPRESSOR = True
 
 TINYMCE_DEFAULT_CONFIG = {
     'extended_valid_elements' :  'iframe[src|width|height|name|align]',
-    'plugins': "table,spellchecker,paste,searchreplace",
+    'plugins': "table,paste,searchreplace",
     'theme': "advanced",
+    'entity_encoding': 'raw',
+    'entities': '160,nbsp,173,shy,8194,ensp,8195,emsp,8201,thinsp,8204,zwnj,8205,zwj,8206,lrm,8207,rlm',
 }
 
 

--- a/edumanage/admin.py
+++ b/edumanage/admin.py
@@ -104,7 +104,7 @@ from tinymce.widgets import TinyMCE
 class TinyMCEFlatPageAdmin(FlatPageAdmin):
     def formfield_for_dbfield(self, db_field, **kwargs):
         if db_field.name == 'content':
-            return forms.CharField(widget=TinyMCE(
+            return db_field.formfield(widget=TinyMCE(
                 attrs={'cols': 80, 'rows': 30},
                 mce_attrs={'external_link_list_url': reverse('tinymce.views.flatpages_link_list')},
             ))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=1.8.11,<1.9a
 argparse>=1.2.1
 django-registration==2.0.4
-django-tinymce==1.5.3
+django-tinymce>=2.3.0,<3.0a
 ipaddr==2.1.11
 python-social-auth==0.2.14
 requests==2.7.0


### PR DESCRIPTION
* raw encoding (rather than HTML entities)
* bump django-tinymce to a "supported" version