### PR TITLE
Minor updates wrt the Sites Framework

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 from django.core.mail import send_mail
-from django.contrib.sites.models import Site
+from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
@@ -98,7 +98,7 @@ def activate(request, activation_key):
             email = render_to_string(
                 'registration/activation_complete.txt',
                 {
-                    'site': Site.objects.get_current(),
+                    'site': get_current_site(request),
                     'user': account
                 }
             )

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -106,6 +106,12 @@ CACHES = {
 #     }
 # }
 
+#### SITES FRAMEWORK ####
+# You must configure (e.g. via Django admin) your canonical public
+# hostname for the site object that matches the SITE_ID configured in
+# settings.py or you can add a different object and override it here:
+# SITE_ID = 1
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -46,6 +46,8 @@ AUTH_USER_MODEL = 'accounts.User'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en'
 
+# The canonical public hostname should be configured for the domain
+# attribute of the site object that matches SITE_ID
 SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -193,6 +193,17 @@ Create a superuser, it comes in handy for access to Django admin. And then run s
 
 Now you should have a clean database with all the tables created.
 
+## Setting up the canonical hostname
+
+You must configure the canonical public hostname of your site for the
+Django Sites Framework to work properly. This is used for example when
+a stable, fully qualified URL must be produced (irrespective of the
+HTTP host). You can use the Django admin interface (see the section
+about *Initial Data*) and browse to
+`https://<hostname>/admin/sites/site/1/` to modify the domain name for
+the default object that was created upon installation, or you can
+create another object and update `SITE_ID` in settings.
+
 ## Collecting static files
 
 **Starting with version 1.1.1 the following process for provisioning

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -21,7 +21,7 @@ from django.contrib.auth import logout
 from django import forms
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.core.mail.message import EmailMessage
-from django.contrib.sites.models import Site
+from django.contrib.sites.shortcuts import get_current_site
 from django.template.loader import render_to_string
 from django.conf import settings
 from django.contrib import messages
@@ -1701,7 +1701,7 @@ def geolocate(request):
 
 @never_cache
 def api(request):
-    current_site = Site.objects.get_current()
+    current_site = get_current_site(request)
     return render_to_response(
         'front/api.html',
         {'site': current_site},
@@ -1759,7 +1759,7 @@ def selectinst(request):
             useradded = userprofile.user
             useradded.email = mailField
             useradded.save()
-            user_activation_notify(userprofile)
+            user_activation_notify(request, userprofile)
             error = _(
                 "User account <strong>%s</strong> is pending activation."
                 " Administrators have been notified and will activate "
@@ -1795,8 +1795,8 @@ def selectinst(request):
             )
 
 
-def user_activation_notify(userprofile):
-    current_site = Site.objects.get_current()
+def user_activation_notify(request, userprofile):
+    current_site = get_current_site(request)
     subject = render_to_string(
         'registration/activation_email_subject.txt',
         {'site': current_site}


### PR DESCRIPTION
* Use django.contrib.sites.shortcuts.get_current_site
* Document the need to configure the Site object matching SITE_ID

It would be preferable to make the Sites Framework optional, but it is used by `django.contrib.flatpages`.