### PR TITLE
Fix custom User model: username MaxLengthValidator also needs patching

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,6 +1,5 @@
 from django.db import models
-from django.contrib.auth.models import AbstractUser
-from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import AbstractUser, validators
 from django.contrib import admin
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
@@ -8,21 +7,28 @@ from edumanage.models import Institution
 import re
 
 
+def patch_username_maxlen(field, maxlen=255):
+    field.max_length = maxlen
+    # try also updating the help_text
+    try:
+        help_text = field.help_text._proxy____args[0]
+        if help_text != None:
+            field.help_text = _(re.sub("[0-9]+(?= characters)",
+                                       str(maxlen),
+                                       help_text))
+    except:
+        pass
+    for v in field.validators:
+        if isinstance(v, validators.MaxLengthValidator):
+            v.limit_value = maxlen
+
 class User(AbstractUser):
     class Meta(AbstractUser.Meta):
         swappable = 'AUTH_USER_MODEL'
         db_table = 'auth_user';
         verbose_name = _('user')
         verbose_name_plural = _('users')
-
-User._meta.get_field('username').max_length = 255
-# try also updating the help_text
-try:
-    help_text = User._meta.get_field('username').help_text._proxy____args[0]
-    if help_text != None:
-	User._meta.get_field('username').help_text = _(re.sub("[0-9]+ characters", "255 characters", help_text))
-except:
-    pass
+patch_username_maxlen(User._meta.get_field('username'))
 
 class UserProfile(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL)


### PR DESCRIPTION
In the context of Django 1.8 migration, longerusername was replaced
with a custom User model. Like the former solution, this also patches
the username field to increase max_length. Alternatively one would
need to add a different field, since field name hiding is not
permitted[1], and have USERNAME_FIELD[2] point to it. But this
involves code duplication which seems unnecessary for such a small
change.

However the patching approach also has issues: It is applied after
CharField is instantiated, which means some things are setup before
max_length is adjusted as intended. MaxLengthValidator is such a case,
so it needs patching too. This is also the approach taken[3] by
longerusername.

This issue is evident in the Django admin interface, where editing any
user field and saving leads to a validation error if the username
exceeds the default max_length (30 characters).

Django documentation[4] suggests that UserCreationForm and UserChangeForm
ModelForms used in UserAdmin must also be overridden, so as to have their
Meta class point to the custom User model. This is again the approach[5]
in longerusername (for older Django versions though, no custom User
model involved). In practice our use case apparently does not require
this (on the contrary actually overriding the forms without adjusting
MaxLengthValidator does not have any effect whatsoever).

[1] https://docs.djangoproject.com/en/1.8/topics/db/models/#field-name-hiding-is-not-permitted
[2] https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD
[3] https://github.com/madssj/django-longer-username-and-email/blob/master/longerusernameandemail/models.py#L23
[4] https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#custom-users-and-the-built-in-auth-forms
[5] https://github.com/madssj/django-longer-username-and-email/blob/master/longerusernameandemail/forms.py