### PR TITLE
Genericise the Management instructions page

### DIFF
--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -81,6 +81,7 @@ EXTRA_AUTHENTICATION_BACKENDS = (
 
 
 SHIB_AUTH_ENTITLEMENT = 'urn:mace:example.com:pki:user'
+SHIB_DOCUMENTATION_URL = 'https://yourfederation.example.com/documentation'
 SHIB_LOGOUT_URL = 'https://example.com/Shibboleth.sso/Logout'
 
 SERVER_EMAIL = "Example domain eduroam Service <noreply@example.com>"

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -81,7 +81,7 @@ EXTRA_AUTHENTICATION_BACKENDS = (
 
 
 SHIB_AUTH_ENTITLEMENT = 'urn:mace:example.com:pki:user'
-SHIB_DOCUMENTATION_URL = 'https://yourfederation.example.com/documentation'
+FEDERATION_DOC_URL = 'https://yourfederation.example.com/documentation'
 SHIB_LOGOUT_URL = 'https://example.com/Shibboleth.sso/Logout'
 
 SERVER_EMAIL = "Example domain eduroam Service <noreply@example.com>"

--- a/djnro/templates/front/management.html
+++ b/djnro/templates/front/management.html
@@ -17,12 +17,14 @@
     <h5>AAI Federation</h5>
     <hr>
     <p>{% blocktrans %}Authentication and authorization are carried out through a{% endblocktrans %} <a href="http://shibboleth.net/products/service-provider.html">Shibboleth SP</a>.</p>
-    <p>{% blocktrans %}The following attributes are required for administrators and must be released by their home IdPs to the SP{% endblocktrans %} {% trans "according to the" %} <a href="http://aai.grnet.gr/documentation">{% trans "policy and procedures documentation" %}</a> {% trans "provided by the" %} {{ FEDERATION_NAME }}:
+    <p>{% blocktrans %}The following attributes are required for administrators and must be released by their home IdPs to the SP{% endblocktrans %} {% trans "according to the" %} <a href="{{ SHIB_DOCUMENTATION_URL }}">{% trans "policy and procedures documentation" %}</a> {% trans "provided by the" %} {{ FEDERATION_NAME }}:
         <table class="table table-bordered">
             <thead><tr><th>{% trans "Attribute" %}</th><th>{% trans "Description" %}</th></tr></thead>
             <tbody>
             <tr class="success"><td>eduPersonPrincipalName</td><td>{% trans "Provides a string that uniquely identifies an administrator in the management application." %}</td></tr>
-            <tr class="success"><td>eduPersonEntitlement</td><td>{% trans "A specific URN value must be provided to authorize an administrator:" %} <strong>urn:mace:grnet.gr:eduroam:admin</strong></td></tr>
+            {% if SHIB_AUTH_ENTITLEMENT %}
+            <tr class="success"><td>eduPersonEntitlement</td><td>{% trans "A specific URN value must be provided to authorize an administrator:" %} <strong>{{ SHIB_AUTH_ENTITLEMENT }}</strong></td></tr>
+            {% endif %}
             <tr class="success"><td>mail</td><td>{% trans "The e-mail address (one or more) of the administrator. It is used for notifications from the management application. It may also be used for further communication, with prior consent." %}</td></tr>
             <tr class="info"><td>givenName (optional)</td><td>{% trans "The person's first name." %}</td></tr>
             <tr class="info"><td>sn (optional)</td><td>{% trans "The person's last name." %}</td></tr>

--- a/djnro/templates/front/management.html
+++ b/djnro/templates/front/management.html
@@ -17,7 +17,7 @@
     <h5>AAI Federation</h5>
     <hr>
     <p>{% blocktrans %}Authentication and authorization are carried out through a{% endblocktrans %} <a href="http://shibboleth.net/products/service-provider.html">Shibboleth SP</a>.</p>
-    <p>{% blocktrans %}The following attributes are required for administrators and must be released by their home IdPs to the SP{% endblocktrans %} {% trans "according to the" %} <a href="{{ SHIB_DOCUMENTATION_URL }}">{% trans "policy and procedures documentation" %}</a> {% trans "provided by the" %} {{ FEDERATION_NAME }}:
+    <p>{% blocktrans %}The following attributes are required for administrators and must be released by their home IdPs to the SP{% endblocktrans %} {% trans "according to the" %} {% if FEDERATION_DOC_URL %}<a href="{{ FEDERATION_DOC_URL }} ">{% endif %}{% trans "policy and procedures documentation" %}{% if FEDERATION_DOC_URL %}</a>{% endif %} {% trans "provided by the" %} {{ FEDERATION_NAME }}:
         <table class="table table-bordered">
             <thead><tr><th>{% trans "Attribute" %}</th><th>{% trans "Description" %}</th></tr></thead>
             <tbody>

--- a/edumanage/context_processors.py
+++ b/edumanage/context_processors.py
@@ -17,7 +17,7 @@ def country_code(context):
         'VERSION': settings.SW_VERSION,
         'GOOGLE_MAPS_API_KEY': settings.GOOGLE_MAPS_API_KEY if hasattr(settings,"GOOGLE_MAPS_API_KEY") else None,
         'SHIB_AUTH_ENTITLEMENT': settings.SHIB_AUTH_ENTITLEMENT if hasattr(settings,"SHIB_AUTH_ENTITLEMENT") else None,
-        'SHIB_DOCUMENTATION_URL': settings.SHIB_DOCUMENTATION_URL if hasattr(settings,"SHIB_DOCUMENTATION_URL") else "http://aai.grnet.gr/documentation",
+        'FEDERATION_DOC_URL': settings.FEDERATION_DOC_URL if hasattr(settings,"FEDERATION_DOC_URL") else None,
     }
 
 

--- a/edumanage/context_processors.py
+++ b/edumanage/context_processors.py
@@ -16,6 +16,8 @@ def country_code(context):
         'MAP_CENTER': settings.MAP_CENTER,
         'VERSION': settings.SW_VERSION,
         'GOOGLE_MAPS_API_KEY': settings.GOOGLE_MAPS_API_KEY if hasattr(settings,"GOOGLE_MAPS_API_KEY") else None,
+        'SHIB_AUTH_ENTITLEMENT': settings.SHIB_AUTH_ENTITLEMENT if hasattr(settings,"SHIB_AUTH_ENTITLEMENT") else None,
+        'SHIB_DOCUMENTATION_URL': settings.SHIB_DOCUMENTATION_URL if hasattr(settings,"SHIB_DOCUMENTATION_URL") else "http://aai.grnet.gr/documentation",
     }
 
 


### PR DESCRIPTION
This patch replaces the GRnet-specific parts of the management instructions with templated variables that come from local_settings.py, allowing other NROs with other AAI federations to use the templated page more easily. It is specifically backwards compatible, meaning that in the absence of a documentation URL it'll revert to the GRnet AAI one. However, it may make more sense to replace this with None.