### PR TITLE
Deprecate Django translation in local_settings.py, provide an alternative for use in templates

### DIFF
--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -1,5 +1,14 @@
+# -*- coding: utf-8 -*- vim:fileencoding=utf-8:
+# vim: tabstop=4:shiftwidth=4:softtabstop=4:expandtab
 import os
-from django.utils.translation import ugettext_lazy as _
+# Marking local settings for translation is not practical, as in
+# principle such strings should not be committed to the source file
+# (locale/en/LC_MESSAGES/django.po).
+# As a workaround translations may be provided in place through a
+# dictionary keyed by language. This is applicable only for settings
+# to be rendered with 'tolocale' in templates (for example
+# NRO_DOMAIN_HELPDESK_DICT).
+#from django.utils.translation import ugettext_lazy as _
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PROJECT_DIR = os.path.join(BASE_DIR, 'djnro')
 
@@ -129,7 +138,7 @@ NRO_DOMAIN_MAIN_URL = "http://www.example.com"
 # NRO federation name
 NRO_FEDERATION_NAME = "GRNET AAI federation"
 # "provided by" info for footer
-NRO_PROV_BY_DICT = {"name": "EXAMPLE NRO TEAM", "url": "http://noc.example.com"}
+NRO_PROV_BY_DICT = {"name": {'en': "EXAMPLE NRO TEAM"}, "url": "http://noc.example.com"}
 # social media contact (Use: // to preserve https)
 NRO_PROV_SOCIAL_MEDIA_CONTACT = [
     {"url": "//facebook.com/example.com", "fa_style":"fa-facebook", "name":"Facebook"},
@@ -137,7 +146,7 @@ NRO_PROV_SOCIAL_MEDIA_CONTACT = [
 ]
 
 # Helpdesk, used in base.html:
-NRO_DOMAIN_HELPDESK_DICT = {"name": _("Domain Helpdesk"), 'email':'helpdesk@example.com', 'phone': '12324567890', 'uri': 'helpdesk.example.com'}
+NRO_DOMAIN_HELPDESK_DICT = {"name": {'en': "Domain Helpdesk"}, 'email':'helpdesk@example.com', 'phone': '12324567890', 'uri': 'helpdesk.example.com'}
 
 #Countries for Realm model:
 REALM_COUNTRIES = (

--- a/djnro/templates/partial/footer.html
+++ b/djnro/templates/partial/footer.html
@@ -7,9 +7,9 @@
     <div>
         <div class="container">
             {% if user.is_authenticated %}
-                {% trans "If you have any questions or need help, contact" %} {% tolocale BRANDING.helpdesk.name LANGUAGE_CODE %} (<a href="{{ BRANDING.helpdesk.uri}}">{{BRANDING.helpdesk.uri}}</a>) - {{BRANDING.helpdesk.phone}}<br>
+                {% trans "If you have any questions or need help, contact" %} {{ BRANDING.helpdesk.name|tolocale:LANGUAGE_CODE }} (<a href="{{ BRANDING.helpdesk.uri}}">{{BRANDING.helpdesk.uri}}</a>) - {{BRANDING.helpdesk.phone}}<br>
             {% endif %}
-            {% trans "This is a service provided by" %} <a href="{{ BRANDING.service_provider.url}}" target="_blank">{% tolocale BRANDING.service_provider.name LANGUAGE_CODE %}</a>
+            {% trans "This is a service provided by" %} <a href="{{ BRANDING.service_provider.url}}" target="_blank">{{BRANDING.service_provider.name|tolocale:LANGUAGE_CODE}}</a>
             {% for media in BRANDING.social_media %}
                 <a href="{{media.url}}" target="_blank">
 		{% if media.local_image %}

--- a/djnro/templates/partial/footer.html
+++ b/djnro/templates/partial/footer.html
@@ -1,14 +1,15 @@
 {% load i18n %}
 {% load template_maybe %}
 {% load staticfiles %}
+{% load tolocale %}
 
 <footer class="stickyfooter">
     <div>
         <div class="container">
             {% if user.is_authenticated %}
-                {% trans "If you have any questions or need help, contact" %} {{ BRANDING.helpdesk.name }} (<a href="{{ BRANDING.helpdesk.uri}}">{{BRANDING.helpdesk.uri}}</a>) - {{BRANDING.helpdesk.phone}}<br>
+                {% trans "If you have any questions or need help, contact" %} {% tolocale BRANDING.helpdesk.name LANGUAGE_CODE %} (<a href="{{ BRANDING.helpdesk.uri}}">{{BRANDING.helpdesk.uri}}</a>) - {{BRANDING.helpdesk.phone}}<br>
             {% endif %}
-            {% trans "This is a service provided by" %} <a href="{{ BRANDING.service_provider.url}}" target="_blank">{{BRANDING.service_provider.name}}</a>
+            {% trans "This is a service provided by" %} <a href="{{ BRANDING.service_provider.url}}" target="_blank">{% tolocale BRANDING.service_provider.name LANGUAGE_CODE %}</a>
             {% for media in BRANDING.social_media %}
                 <a href="{{media.url}}" target="_blank">
 		{% if media.local_image %}

--- a/edumanage/templatetags/tolocale.py
+++ b/edumanage/templatetags/tolocale.py
@@ -18,6 +18,12 @@ class CurrentLocaleNode(template.Node):
     def render(self, context):
         objtrans = self.objtrans.resolve(context)
         translang = self.format_string.resolve(context)
-        return objtrans.get_name(lang=translang)
+        try:
+            return objtrans.get_name(lang=translang)
+        except AttributeError:
+            if isinstance(objtrans, dict):
+                return objtrans.get(translang, '')
+            else:
+                return objtrans
 
 register.tag('tolocale', do_tolocale)

--- a/edumanage/templatetags/tolocale.py
+++ b/edumanage/templatetags/tolocale.py
@@ -1,9 +1,9 @@
 from django import template
-from edumanage.models import * 
 
 register = template.Library()
 
-def do_tolocale(parser, token):
+@register.tag
+def tolocale(parser, token):
     try:
         tag_name, objtrans, format_string = token.split_contents()
     except ValueError:
@@ -18,12 +18,15 @@ class CurrentLocaleNode(template.Node):
     def render(self, context):
         objtrans = self.objtrans.resolve(context)
         translang = self.format_string.resolve(context)
-        try:
-            return objtrans.get_name(lang=translang)
-        except AttributeError:
-            if isinstance(objtrans, dict):
-                return objtrans.get(translang, '')
-            else:
-                return objtrans
+        return tolocale_filter(objtrans, translang)
 
-register.tag('tolocale', do_tolocale)
+
+@register.filter(name='tolocale')
+def tolocale_filter(objtrans, translang):
+    try:
+        return objtrans.get_name(lang=translang)
+    except AttributeError:
+        if isinstance(objtrans, dict):
+            return objtrans.get(translang, '')
+        else:
+            return objtrans


### PR DESCRIPTION
Let tolocale also try to resolve translations with a dict lookup, and
register it both as a template tag and filter, so that it may be able
to provide the former alternative.