### PR TITLE
Fix and extend the in-place translation facility for local_settings.py

### DIFF
--- a/djnro/lldict.py
+++ b/djnro/lldict.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.utils.functional import SimpleLazyObject
+from django.utils.encoding import smart_text
+
+class LazyLangDict(SimpleLazyObject):
+    def __init__(self, *args, **kwargs):
+        def _setupfunc():
+            dct = dict(*args, **kwargs)
+            for lang in dct:
+                if lang not in dict(settings.LANGUAGES):
+                    del dct[lang]
+            return dct
+        super(LazyLangDict, self).__init__(_setupfunc)
+    def __unicode__(self):
+        if len(self):
+            k, v = next(iter(self.items()))
+            return smart_text(v)
+        else:
+            return super(LazyLangDict, self).__unicode__()

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -7,7 +7,10 @@ import os
 # As a workaround translations may be provided in place through a
 # dictionary keyed by language. This is applicable only for settings
 # to be rendered with 'tolocale' in templates (for example
-# NRO_DOMAIN_HELPDESK_DICT).
+# NRO_DOMAIN_HELPDESK_DICT). Wrapping such a dictionary with
+# djnro.lldict.LazyLangDict ensures that an (arbitrary) string value
+# will be returned where a dict is not expected.
+from djnro.lldict import LazyLangDict as _
 #from django.utils.translation import ugettext_lazy as _
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PROJECT_DIR = os.path.join(BASE_DIR, 'djnro')
@@ -139,7 +142,7 @@ NRO_DOMAIN_MAIN_URL = "http://www.example.com"
 # NRO federation name
 NRO_FEDERATION_NAME = "GRNET AAI federation"
 # "provided by" info for footer
-NRO_PROV_BY_DICT = {"name": {'en': "EXAMPLE NRO TEAM"}, "url": "http://noc.example.com"}
+NRO_PROV_BY_DICT = {"name": _({'en': "EXAMPLE NRO TEAM"}), "url": "http://noc.example.com"}
 # social media contact (Use: // to preserve https)
 NRO_PROV_SOCIAL_MEDIA_CONTACT = [
     {"url": "//facebook.com/example.com", "fa_style":"fa-facebook", "name":"Facebook"},
@@ -147,11 +150,11 @@ NRO_PROV_SOCIAL_MEDIA_CONTACT = [
 ]
 
 # Helpdesk, used in base.html:
-NRO_DOMAIN_HELPDESK_DICT = {"name": {'en': "Domain Helpdesk"}, 'email':'helpdesk@example.com', 'phone': '12324567890', 'uri': 'helpdesk.example.com'}
+NRO_DOMAIN_HELPDESK_DICT = {"name": _({'en': "Domain Helpdesk"}), 'email':'helpdesk@example.com', 'phone': '12324567890', 'uri': 'helpdesk.example.com'}
 
 #Countries for Realm model:
 REALM_COUNTRIES = (
-    ('country_2letters', 'Country' ),
+    ('country_2letters', _({'en': 'Country'}) ),
 )
 
 # List the login methods to be offered to users here.

--- a/djnro/templates/front/participants.html
+++ b/djnro/templates/front/participants.html
@@ -11,7 +11,7 @@
 {% load tolocale %}
 <h1>{% trans "Participating Institutions" %}</h1>
 <hr>
-<div>{% trans "In"%} {% trans COUNTRY_NAME %} {% trans "eduroam is provided by the following institutions/organizations" %}</div>
+<div>{% trans "In"%} {% tolocale COUNTRY_NAME LANGUAGE_CODE %} {% trans "eduroam is provided by the following institutions/organizations" %}</div>
 <br/>
 <div class="row">
 	{% for i in institutions %}


### PR DESCRIPTION
* Add djnro.lldict.LazyLangDict, a dict-like object that
  * lazily filters keys by settings.LANGUAGES and
  * returns an arbitrary value in __unicode__() context.
* Use said object to wrap in-place translation in local_settings.py
* Extend in-place translation to REALM_COUNTRIES, an iterable that
  provides
  * choices for edumanage.models.Realm.country, where Django
    seeks a text value for the label,
  * the COUNTRY_NAME context variable, which is used e.g. in
    'participants' template, where in-place translation is desirable.
  The new dict wrapper object accommodates both such needs.