### PR TITLE
Implement Shibboleth SP mechanism for supporting Single Logout (SLO)

### DIFF
--- a/djnro/urls.py
+++ b/djnro/urls.py
@@ -12,7 +12,7 @@ urlpatterns = patterns(
     url(r'^managelogin/(?P<backend>[^/]+)/$', 'edumanage.views.manage_login', name='manage_login'),
     url(r'^login/?', 'edumanage.views.user_login', name="login"),
     url(r'^altlogin/?', 'django.contrib.auth.views.login', {'template_name': 'overview/login.html'}, name="altlogin"),
-    url(r'^logout/?', 'django.contrib.auth.views.logout', {'next_page': '/'}, name="logout"),
+    url(r'^logout/?', 'edumanage.views.user_logout', {'next_page': '/'}, name="logout"),
     url(r'^registration/accounts/activate/(?P<activation_key>\w+)/$', 'accounts.views.activate', name='activate_account'),
     url(
         r'^registration/activate/complete/$',


### PR DESCRIPTION
* Add a field in the user session to tell apart users logging with
  with (Shibboleth) SSO.
* Add a user_logout view (pointing 'logout' URL to it), which:
  * acts as a wrapper for django.contrib.auth.views.logout,
  * sets next_page to (previously unused) settings.SHIB_LOGOUT_URL for
    SSO users,
  * sets REDIRECT_FIELD_NAME upon detecting a Shibboleth front-channel
    logout notification (action=logout&return=...)