### PR TITLE
Make the servdata YAML more complete

### DIFF
--- a/edumanage/management/commands/servdata.py
+++ b/edumanage/management/commands/servdata.py
@@ -74,6 +74,8 @@ def servdata():
         if srv.name:
             srv_dict['label'] = srv.name
         srv_dict['secret'] = srv.secret
+        srv_dict['addr_type'] = srv.addr_type
+        srv_dict['proto'] = srv.proto
         root['clients'].update({srv_id: srv_dict})
 
     servers = hosts.filter(ertype__in=[1,3])
@@ -92,6 +94,8 @@ def servdata():
             srv_dict['label'] = srv.name
         srv_dict['secret'] = srv.secret
         srv_dict['status_server'] = bool(srv.status_server)
+        srv_dict['addr_type'] = srv.addr_type
+        srv_dict['proto'] = srv.proto
         root['servers'].update({srv_id: srv_dict})
 
     if insts:

--- a/extras/radsecproxy.tpl
+++ b/extras/radsecproxy.tpl
@@ -46,7 +46,11 @@ rewrite rewrite-${client}-sp {
 }
 client ${client} {
         host ${clients[client]['host']}
+% if clients[client]['addr_type'] == 'ipv4':
         IPv4Only on
+% elif clients[client]['addr_type'] == 'ipv6':
+        IPv6Only on
+% endif
         type udp
         secret ${clients[client]['secret'] | percent_escape}
         fticksVISCOUNTRY GR
@@ -82,7 +86,11 @@ rewrite rewrite-${srv}-idp {
 }
 server ${srv}${'-acct' if servers[srv]['rad_pkt_type'] == 'acct' else ''} {
         host ${servers[srv]['host']}
+% if servers[srv]['addr_type'] == 'ipv4':
         IPv4Only on
+% elif servers[srv]['addr_type'] == 'ipv6':
+        IPv6Only on
+% endif
         type udp
         port ${servers[srv]['auth_port'] if servers[srv]['rad_pkt_type'] in ('auth', 'auth+acct') else servers[srv]['acct_port']}
         secret ${servers[srv]['secret'] | percent_escape}


### PR DESCRIPTION
The current YAML output from the servdata command does not include two pieces of information current model: proto and addr_type. Whilst the former is currently not really used in DjNRO, the latter is useful when one wants to provide the option for IPv6 support in a RADIUS server that supports it.

This pull request includes two commits.

The first adds the two missing pieces of data to the YAML output (both are included for completeness). This should be backwards compatible since it's only adding additional information to the YAML which existing implementations should ignore.

The second updates the existing radsecproxy.tpl example template to make use of the addr_type entry to control the generation of the IPv4Only and IPv6Only flags. This may have backwards compatability issues if anyone depends on this template, since the current version generates `IPv4Only on` for all entries regardless of the addr_type, and the new version will leave it out for addr_type any (so permitting IPv6).