### PR TITLE
Templates: always use current v3 GMaps API release

### DIFF
--- a/djnro/templates/edumanage/instrealmmon_edit.html
+++ b/djnro/templates/edumanage/instrealmmon_edit.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block extrajs %}
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?{% if GOOGLE_MAPS_API_KEY %}key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
+<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
 {% endblock %}
 
 {% block management_content %}

--- a/djnro/templates/edumanage/servers_edit.html
+++ b/djnro/templates/edumanage/servers_edit.html
@@ -135,7 +135,7 @@
 
 {% block extrajs %}
 <script type="text/javascript" src="{% static 'js/showpass.js' %}"></script>
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?{% if GOOGLE_MAPS_API_KEY %}key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
+<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
 <script type="text/javascript">
 $(document).ready(function() {
 	$('#id_secret').showPassword();

--- a/djnro/templates/edumanage/service_details.html
+++ b/djnro/templates/edumanage/service_details.html
@@ -15,7 +15,7 @@
 		width: auto !important;
 	}
 </style>
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?{% if GOOGLE_MAPS_API_KEY %}key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
+<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
 <script type="text/javascript">
         var map = '';
         var lat = "{{service.latitude}}";

--- a/djnro/templates/edumanage/services_edit.html
+++ b/djnro/templates/edumanage/services_edit.html
@@ -250,7 +250,7 @@
 
 {% block extrajs %}
 <script type="text/javascript" src="{% static 'js/jquery.formset.js' %}"></script>
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3.exp{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}&amp;language=en&amp;libraries=places"></script>
+<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}&amp;language=en&amp;libraries=places"></script>
 <script src="{% static 'js/jquery_csrf_protect.js' %}" type="text/javascript"></script>
 
 <script type="text/javascript">

--- a/djnro/templates/edumanage/welcome.html
+++ b/djnro/templates/edumanage/welcome.html
@@ -101,6 +101,6 @@
 
 {% block extrajs %}
 <script type="text/javascript" src="{% static 'js/markerclusterer.js' %}"></script>
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?{% if GOOGLE_MAPS_API_KEY %}key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
+<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}"></script>
 <script type="text/javascript" src="{% static 'js/management-map.js' %}"></script>
 {% endblock %}

--- a/djnro/templates/front/geolocate.html
+++ b/djnro/templates/front/geolocate.html
@@ -40,6 +40,6 @@
 {% endblock %}
 
 {% block extrajs %}
-<script type="text/javascript" src="//maps.google.com/maps/api/js?v=3.exp{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}&amp;language=en&amp;libraries=places"></script>
+<script type="text/javascript" src="//maps.google.com/maps/api/js?v=3{% if GOOGLE_MAPS_API_KEY %}&amp;key={{ GOOGLE_MAPS_API_KEY }}{% endif %}&amp;language=en&amp;libraries=places"></script>
 <script type="text/javascript" src="{% static 'js/geolocate.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Hi @zmousm ,

Long time no see, long time no PR :-)

I have just run into an issue where some pages were handing while loading - especially the management welcome/landing page.

It was hanging while loading Google Maps - and I noticed this page wasn't passing the "v" parameter to select version.  Adding "v=3" fixed the loading/hanging issue.

I've checked and unified the use of Google Maps across all templates loading them:
* Some templates were asking for experimental, but these features must have made it into release by now.
* Some templates were not passing the "v" parameter at all, which was causing the loading to hang.

All now pass "v=3".

Please let me know if happy to merge.

Cheers,
Vlad