### PR TITLE
CATv2 API changes

### DIFF
--- a/utils/cat_helper.py
+++ b/utils/cat_helper.py
@@ -91,8 +91,7 @@ class CatQuery(object):
                 params[id]['NAME'] = kwargs[k]
             elif k.startswith('value[S'):
                 if k.endswith('-lang]'):
-                    if kwargs[k] != 'C':
-                        params[id]['LANG'] = kwargs[k]
+                    params[id]['LANG'] = kwargs[k]
                 else:
                     params[id]['VALUE'] = kwargs[k]
         return filter(None, params)


### PR DESCRIPTION
With the release of CAT 2.0-beta1 comes a significant change in the CAT [admin API](https://github.com/GEANT/CAT/blob/master/Changes.md). This change is not [backwards compatible](https://wiki.geant.org/display/H2eduroam/A+guide+to+eduroam+CAT+2.0+and+eduroam+Managed+IdP+for+National+Roaming+Operator+administrators#AguidetoeduroamCAT2.0andeduroamManagedIdPforNationalRoamingOperatoradministrators-UI-lessAutomatedManagement:theAdminAPI(2.0)), and the old API version is no longer supported in production.

DjNRO abstracts its CAT API calls into a `CatQuery` class, but the parameters passed to functions in this class are explicitly derived from v1 of the CAT API. This change introduces support for the CATv2 admin API while preserving the DjNRO `CatQuery` abstraction interface. By doing this, we avoid making changes to other parts of the DjNRO code base at the expense of slightly complicating the `CatQuery` class.

Part of the reason I've elected to do things in this way is that the `CatQuery` class contains functions and static methods that are not called from elsewhere within the published DjNRO code base, making it unclear as to why they exist -- and leading to the assumption that they're used by other, unpublished utilities.