### PR TITLE
connect: let CAT user API drive device detection

### DIFF
--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -275,6 +275,7 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = []
 #         'profileAttributes':         _5m,
 #         'sendLogo':                 _15m,
 #         'deviceInfo':                _5m,
+#         'detectOS':                 _15m,
 #     }
 # }
 

--- a/djnro/static/js/cat_api.js
+++ b/djnro/static/js/cat_api.js
@@ -1201,9 +1201,10 @@
 	'vista': [/Windows NT 6[._]0/],
 	'w7': [/Windows NT 6[._]1/],
 	'w8': [/Windows NT 6[._][23]/],
-	'w10': [/Windows NT 10[._]/, /Windows NT 1[1-9]/, /Windows NT [2-9][0-9]/],
+	'w10': [/Windows NT 10/],
 	'mobileconfig-56': [/\((iPad|iPhone|iPod);.*OS [56]_/],
-	'mobileconfig': [/\((iPad|iPhone|iPod);.*OS [7-9]/, /\((iPad|iPhone|iPod);.*OS [1-9][0-9]/],
+	'mobileconfig': [/\((iPad|iPhone|iPod);.*OS [7-9]/, /\((iPad|iPhone|iPod);.*OS 1[0-1]/],
+	'mobileconfig12': [/\((iPad|iPhone|iPod);.*OS 1[2-9]/],
 	'apple_lion': [/Mac OS X 10[._]7/],
 	'apple_m_lion': [/Mac OS X 10[._]8/],
 	'apple_mav': [/Mac OS X 10[._]9/],
@@ -1216,11 +1217,12 @@
 	'chromeos': [/CrOS/],
 	'android_43': [/Android 4[._]3/],
 	'android_kitkat': [/Android 4[._][4-9]/],
-	'android_lollipop': [/Android 5[._][0-9]/],
-	'android_marshmallow': [/Android 6[._][0-9]/],
-	'android_nougat': [/Android 7[._][0-9]/],
-	'android_oreo': [/Android 8[._][0-9]/],
-	'android_pie': [/Android 9/, /Android [1-9][0-9]/],
+	'android_lollipop': [/Android 5/],
+	'android_marshmallow': [/Android 6/],
+	'android_nougat': [/Android 7/],
+	'android_oreo': [/Android 8/],
+	'android_pie': [/Android 9/],
+	'android_q': [/Android [1-9][0-9]/],
 	'android_legacy': [/Android/],
 	'__undefined__': [ new RegExp('') ]
     }
@@ -1335,7 +1337,6 @@
 	deviceIDs = Array.isArray(deviceIDs) ? deviceIDs : Object.keys(UAs);
 	var cb = function(dev_id_obj) {
 	    return !!dev_id_obj && !!dev_id_obj.id &&
-		(dev_id_obj.id in UAs) &&
 		dev_id_obj.id ||
 		deviceIDs.pop(); // assume last resort at the end
 	}

--- a/djnro/static/js/cat_ui.js
+++ b/djnro/static/js/cat_ui.js
@@ -1023,6 +1023,19 @@
 		    .then(self.setup_devicelist_cb2, self.setup_devicelist_cb2)
 	    );
 
+	    if (!('catDeviceGuess' in cuopts) && CAT.API.options.api_version >= 2) {
+		var detect_device_id_cb = function(device_id) {
+		    if (!('catDeviceGuess' in cuopts) && device_id) {
+			cuopts.catDeviceGuess = device_id;
+		    }
+		}
+		deferreds.push(
+		    $.when(
+			CAT.Device().detectDeviceID()
+		    ).then(detect_device_id_cb, detect_device_id_cb)
+		);
+	    }
+
 	    return $.when.apply($, deferreds)
 		.then(
 		    function() {
@@ -1716,7 +1729,7 @@
 		}
 	    }('IdentityProvider', 'Profile', 'Device'));
 	}
-	if (!('catDeviceGuess' in cuopts)) {
+	if (!('catDeviceGuess' in cuopts) && CAT.API.options.api_version < 2) {
 	    cuopts.catDeviceGuess =
 		catPrototypes.Device.guessDeviceID(navigator.userAgent);
 	}

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -2482,6 +2482,7 @@ def _cat_api_cache_action(request, cat_instance):
         'orderIdentityProviders':   600,
         'listCountries':            600,
         'sendLogo':                 600,
+        'detectOS':                 600,
         }
     timeouts_settings = getattr(settings, 'CAT_USER_API_CACHE_TIMEOUT', {})
     timeouts = timeouts_settings.get(cat_instance, timeouts_default)
@@ -2563,6 +2564,8 @@ def cat_user_api_proxy(request, cat_instance):
             patch_vary_headers(resp, ['Origin'])
         resp.setdefault('Access-Control-Allow-Origin', origin)
         resp.setdefault('Access-Control-Allow-Method', 'GET')
+    if cat_api_action == 'detectOS':
+        patch_vary_headers(resp, ['User-Agent'])
     if cd is not None:
         resp.setdefault('Content-Disposition', cd)
     resp.setdefault('Cache-Control', cc)


### PR DESCRIPTION
Device detection was delegated to `cat_api.js` (`Device.guessDeviceID`), which mimicked the way CAT matches the `User-Agent` against device modules. CAT version 2 offers a user API method `detectOS`, which can be used instead, alleviating the need to keep updating `USER_AGENTS` in `cat_api.js` in order to follow device matching in CAT.

* Update `cat_ui` to prefer this method when used against CAT API version 2 or later.
* Let `cat_user_api_proxy` vary on `User-Agent` for caching responses for action `detectOS`
  * and enable caching for such responses by default