### PR TITLE
Connect: visually distinguish CAT-bound institutions

### DIFF
--- a/djnro/static/css/connect.css
+++ b/djnro/static/css/connect.css
@@ -189,13 +189,22 @@ ul.insts.filtered li:not(.match) {
 
 /* when an institution selector is CAT-bound, the following arrow
    (visual distinction) should be hidden */
-ul.insts a[data-toggle="modal"] i {
+ul.insts a[data-toggle="modal"] i.connect-link {
+    display: none;
+  }
+/* and instead a different icon shown */
+ul.insts a[data-toggle="link"] i.connect-cat {
     display: none;
   }
 /* otherwise it should be displayed inline */
 ul.insts a i {
     display: inline;
 }
+
+/* distinguish CAT-enabled institutions */
+ul.insts a[data-toggle="modal"] {
+    border: .1rem solid green;
+  }
 
 /* xxxxxxxx CAT UI xxxxxxxx */
 

--- a/djnro/static/js/cat_ui.js
+++ b/djnro/static/js/cat_ui.js
@@ -549,7 +549,7 @@
 		    return false;
 		}
 		$el.removeData('_catidp');
-		$el.attr({'data-toggle': null,
+		$el.attr({'data-toggle': 'link',
 			  'data-target': null})
 		    .removeData('toggle target');
 		var href = $(this).attr('href');

--- a/djnro/templates/front/connect.html
+++ b/djnro/templates/front/connect.html
@@ -73,10 +73,10 @@
 	     data-idu="{% url 'participants' %}"
 	     data-iid="{{ i.institution.pk }}" data-catidp="{{catidp}}" tabindex="0">
 	  {% else %}
-	  <a class="btn" data-iid="{{ i.institution.pk }}"
+	  <a class="btn" data-toggle="link" data-iid="{{ i.institution.pk }}"
 	     href="{% url 'participants' %}" tabindex="0">
 	  {% endif %}
-	  <span class="title" {% if i.oper_name %}data-on="{{i.oper_name}}"{% endif %}>{% tolocale i.institution LANGUAGE_CODE %}</span><span class="small-small hidden">&nbsp;<span class="distance"></span>&nbsp;Km</span>&nbsp;<i title="{% trans 'See info (instructions, contacts) for this institution' %}" data-toggle="tooltip" data-placement="bottom" class="fa fa-arrow-circle-right text-muted"></i>
+	  <span class="title" {% if i.oper_name %}data-on="{{i.oper_name}}"{% endif %}>{% tolocale i.institution LANGUAGE_CODE %}</span><span class="small-small hidden">&nbsp;<span class="distance"></span>&nbsp;Km</span>&nbsp;<i title="{% trans 'See info (instructions, contacts) for this institution' %}" data-toggle="tooltip" data-placement="bottom" class="fa fa-arrow-circle-right text-muted connect-link"></i><i title="{% trans 'Use CAT profile created for this institution' %}" data-toggle="tooltip" data-placement="bottom" class="fa fa-wifi text-muted connect-cat"></i>
 	  </a>
 	</li>
 	{% endwith %}


### PR DESCRIPTION
Hi @zmousm ,

Thanks for the work on #57 - that has finally made CAT usable for us.

And we started using it.  And we realized we need to help our users navigate through the Connect page - we thought we should increase the visual difference between CAT-enabled institutions and those that just link to the Participants page.

I've added a light border around the CAT-enabled ones, plus added an icon for them (ended up picking "wifi" from FA) to be the counterpart of the link arrow.  Than just had to add data-toggle attribute for the non-CAT institutions as well to allow *positive* selection in the CSS.

Please let me know if this looks OK to you to merge (on visual and code aspects).

Thanks a lot in advance for getting back to me.

Cheers,
Vlad