### PR TITLE
connect: tweak template to enable overriding selectors in the institution list

### DIFF
--- a/djnro/templates/base.html
+++ b/djnro/templates/base.html
@@ -13,7 +13,7 @@
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{% static 'img/edu114-icon.png' %}">
 <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{% static 'img/edu72-icon.png' %}">
 <link rel="apple-touch-icon-precomposed" href="{% static 'img/edu-icon.png' %}">
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
 <link href="{% static 'css/style.css' %}" rel="stylesheet">
 {% block extrahead %}{% endblock %}

--- a/djnro/templates/front/connect.html
+++ b/djnro/templates/front/connect.html
@@ -68,6 +68,7 @@
 	{% for i in institutions %}
 	{% with catidp=institutions_cat|dict_lookup:i.institution.pk %}
 	<li>
+	  {% block cat_institution_selector %}
 	  {% if catidp and catexists %}
 	  <a class="btn" data-toggle="modal" data-target="catModal"
 	     data-idu="{% url 'participants' %}"
@@ -78,6 +79,7 @@
 	  {% endif %}
 	  <span class="title" {% if i.oper_name %}data-on="{{i.oper_name}}"{% endif %}>{% tolocale i.institution LANGUAGE_CODE %}</span><span class="small-small hidden">&nbsp;<span class="distance"></span>&nbsp;Km</span>&nbsp;<i title="{% trans 'See info (instructions, contacts) for this institution' %}" data-toggle="tooltip" data-placement="bottom" class="fa fa-arrow-circle-right text-muted"></i>
 	  </a>
+	  {% endblock %}
 	</li>
 	{% endwith %}
 	{% endfor %}

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -236,6 +236,9 @@ The note about the cat-users mailing list, shown after support contacts.
 The footnote attributing the CAT service being used.
 It should include an <a data-catui="cat-api-tou"> element.
 {% endblock %}
+{% block cat_institution_selector %}
+The button acting as the institution selector for each individual institution in the institution list.
+{% endblock %}
 ```
 
 The custom template should then be configured in the `CAT_CONNECT_TEMPLATE` setting, for the `production` instance. See the default template in `djnro/templates/front/connect.html` and the preceding comments in `local_settings.py.dist` for more details.


### PR DESCRIPTION
Hi @zmousm ,

Thanks for the detailed suggestions in #60 - works for me perfectly.
I've now added the suggested `cat_institution_selector` template block (and also bumped font-awesome to 4.7.0).

I was looking for a more suitable icon to use in our setup - I found https://fontawesome.com/icons/user-cog?style=solid, but that would require font-awesome 5, and that might be too much of an overhaul.

I'm in the end using "cogs" icon in our setup - that provides a hint to the users that this might be setting their device up.

Happy to contribute the icon bit if you in the end find it useful - but also happy just having it in a local template.

Leaving this one for you to look at (but understand this would be also OK to merge right away...)

Cheers,
Vlad

