### PR TITLE
selectinst: return 400 Bad Request for method!=GET

### DIFF
--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1825,6 +1825,8 @@ def selectinst(request):
                 context={'form': form, 'nomail': nomail}
             )
 
+    else:
+        return HttpResponseBadRequest('<h1>Only POST requests are allowed at this URL.</h1>')
 
 def user_activation_notify(request, userprofile):
     current_site = get_current_site(request)


### PR DESCRIPTION
... otherwise, the code returns None, which causes an exception in the @never_cache decorator.

Replace an embarassing stack trace / 500 error page with a more graceful error message.