### PR TITLE
Python3 compatibility - preserving Python2

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,4 +1,4 @@
 VERSION = '1.1.1'
 
 if __name__ == "__main__":
-    print VERSION
+    print(VERSION)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib import admin
 from django.conf import settings
 from django.core import validators
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from edumanage.models import Institution
 import re
@@ -31,6 +32,7 @@ class User(AbstractUser):
         verbose_name_plural = _('users')
 patch_username_maxlen(User._meta.get_field('username'))
 
+@python_2_unicode_compatible
 class UserProfile(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL)
     institution = models.ForeignKey(Institution)
@@ -41,5 +43,5 @@ class UserProfile(models.Model):
             ("overview", "Can see registered user and respective institutions"),
         )
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s:%s" % (self.user.username, self.institution)

--- a/djnro/lldict.py
+++ b/djnro/lldict.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_text, python_2_unicode_compatible
 
+@python_2_unicode_compatible
 class LazyLangDict(SimpleLazyObject):
     def __init__(self, *args, **kwargs):
         def _setupfunc():
@@ -11,9 +12,9 @@ class LazyLangDict(SimpleLazyObject):
                     del dct[lang]
             return dct
         super(LazyLangDict, self).__init__(_setupfunc)
-    def __unicode__(self):
+    def __str__(self):
         if len(self):
             k, v = next(iter(self.items()))
             return smart_text(v)
         else:
-            return super(LazyLangDict, self).__unicode__()
+            return super(LazyLangDict, self).__str__()

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -304,7 +304,7 @@ def _dictmerge(a, b):
             ret[key] = _dictmerge(a[key], b[key])
     return ret
 
-from local_settings import *  # noqa
+from djnro.local_settings import *  # noqa
 for var, val in [i for i in locals().items() if i[0].startswith('EXTRA_')]:
     name = var[len('EXTRA_'):]
     try:

--- a/edumanage/admin.py
+++ b/edumanage/admin.py
@@ -76,7 +76,7 @@ class MonLocalAuthnParamAdmin(admin.ModelAdmin):
 
 
 class CatEnrollmentAdmin(admin.ModelAdmin):
-    list_display = ('__unicode__', 'cat_active')
+    list_display = ('__str__', 'cat_active')
     list_filter = ('cat_instance',)
 
 admin.site.register(Name_i18n)

--- a/edumanage/forms.py
+++ b/edumanage/forms.py
@@ -13,7 +13,7 @@ from accounts.models import UserProfile
 from edumanage.fields import MultipleEmailsField
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
 
-import ipaddr
+import ipaddress
 import re
 
 FQDN_RE = r'(^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$)'
@@ -123,11 +123,11 @@ class InstServerForm(forms.ModelForm):
             if not match:
                 try:
                     if addr_type == 'any':
-                        address = ipaddr.IPAddress(host)
+                        address = ipaddress.ip_address(host)
                     if addr_type == 'ipv4':
-                        address = ipaddr.IPv4Address(host)
+                        address = ipaddress.IPv4Address(host)
                     if addr_type == 'ipv6':
-                        address = ipaddr.IPv6Address(host)
+                        address = ipaddress.IPv6Address(host)
                 except Exception:
                         error_text = _('Invalid network address/hostname format')
                         raise forms.ValidationError(error_text)

--- a/edumanage/forms.py
+++ b/edumanage/forms.py
@@ -180,9 +180,9 @@ class NameFormSetFact(BaseGenericInlineFormSet):
                 empty_forms = False
             langs.append(form.cleaned_data.get('lang', None))
         if empty_forms:
-            raise forms.ValidationError, _("Fill in at least one location name in English")
+            raise forms.ValidationError(_("Fill in at least one location name in English"))
         if "en" not in langs:
-            raise forms.ValidationError, _("Fill in at least one location name in English")
+            raise forms.ValidationError(_("Fill in at least one location name in English"))
 
 
 class UrlFormSetFact(BaseGenericInlineFormSet):
@@ -208,6 +208,6 @@ class UrlFormSetFactInst(BaseGenericInlineFormSet):
                 empty_forms = False
             url_types.append(form.cleaned_data.get('urltype', None))
         if empty_forms:
-            raise forms.ValidationError, _("Fill in at least the info url")
+            raise forms.ValidationError(_("Fill in at least the info url"))
         if "info" not in url_types:
-            raise forms.ValidationError, _("Fill in at least the info url")
+            raise forms.ValidationError(_("Fill in at least the info url"))

--- a/edumanage/forms.py
+++ b/edumanage/forms.py
@@ -71,20 +71,20 @@ class InstServerForm(forms.ModelForm):
 
     def clean_ertype(self):
         ertype = self.cleaned_data['ertype']
-	if not ertype:
-	    raise forms.ValidationError('This field is required.')
+        if not ertype:
+            raise forms.ValidationError('This field is required.')
         for institution in self.inst_list:
-	    inst_type = institution.ertype
-	    type_list = [inst_type]
-	    if inst_type == 3:
-		type_list = [1, 2, 3]
+            inst_type = institution.ertype
+            type_list = [inst_type]
+            if inst_type == 3:
+                type_list = [1, 2, 3]
             if ertype not in type_list:
                 raise forms.ValidationError('Server type cannot be different than institution type (%s)' %dict(self.fields['ertype'].choices)[inst_type])
-	return self.cleaned_data["ertype"]
+        return self.cleaned_data["ertype"]
 
     def clean_auth_port(self):
         auth_port = self.cleaned_data['auth_port']
-	if not 'ertype' in self.cleaned_data:
+        if not 'ertype' in self.cleaned_data:
                 raise forms.ValidationError(_('The Type field is required to validate this field.'))
         ertype = self.cleaned_data['ertype']
         if ertype in [1,3]:
@@ -95,7 +95,7 @@ class InstServerForm(forms.ModelForm):
 
     def clean_acct_port(self):
         acct_port = self.cleaned_data['acct_port']
-	if not 'ertype' in self.cleaned_data:
+        if not 'ertype' in self.cleaned_data:
                 raise forms.ValidationError(_('The Type field is required to validate this field.'))
         ertype = self.cleaned_data['ertype']
         if ertype in [1,3]:
@@ -106,7 +106,7 @@ class InstServerForm(forms.ModelForm):
 
     def clean_rad_pkt_type(self):
         rad_pkt_type = self.cleaned_data['rad_pkt_type']
-	if not 'ertype' in self.cleaned_data:
+        if not 'ertype' in self.cleaned_data:
                 raise forms.ValidationError(_('The Type field is required to validate this field.'))
         ertype = self.cleaned_data['ertype']
         if ertype in [1,3]:

--- a/edumanage/management/commands/contacts.py
+++ b/edumanage/management/commands/contacts.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                 and u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
             ) for m in u.email.split(';')
         ]
-        data.sort(key=lambda d: locale.strxfrm(unicode(d[0])))
+        data.sort(key=lambda d: locale.strxfrm(six.text_type(d[0])))
         for (foreas, onoma, email) in data:
             if options['maillist']:
                 self.stdout.write(

--- a/edumanage/management/commands/contacts.py
+++ b/edumanage/management/commands/contacts.py
@@ -16,6 +16,7 @@ locale.setlocale(locale.LC_COLLATE, ('el_GR', 'UTF-8'))
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
+from django.utils import six
 from accounts.models import User
 
 
@@ -33,6 +34,14 @@ class Command(BaseCommand):
             default=False,
             help='Return only emails (output suitable for a mailing list)'
         )
+
+    def get_str_func(self):
+        """Return a function suitable for conversion to string"""
+
+        if six.PY3:
+            return str
+        else:
+            return lambda s: unicode(s).encode('utf-8')
 
     def handle(self, *args, **options):
         users = User.objects.all()
@@ -55,7 +64,7 @@ class Command(BaseCommand):
                 and u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
             ) for m in u.email.split(';')
         ]
-        data.sort(key=lambda d: locale.strxfrm(str(d[0])))
+        data.sort(key=lambda d: locale.strxfrm(self.get_str_func()(d[0])))
         for (foreas, onoma, email) in data:
             if options['maillist']:
                 self.stdout.write(

--- a/edumanage/management/commands/contacts.py
+++ b/edumanage/management/commands/contacts.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                 and u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
             ) for m in u.email.split(';')
         ]
-        data.sort(cmp=locale.strcoll, key=lambda d: unicode(d[0]))
+        data.sort(key=lambda d: locale.strxfrm(unicode(d[0])))
         for (foreas, onoma, email) in data:
             if options['maillist']:
                 self.stdout.write(

--- a/edumanage/management/commands/contacts.py
+++ b/edumanage/management/commands/contacts.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                 and u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
             ) for m in u.email.split(';')
         ]
-        data.sort(key=lambda d: locale.strxfrm(six.text_type(d[0])))
+        data.sort(key=lambda d: locale.strxfrm(str(d[0])))
         for (foreas, onoma, email) in data:
             if options['maillist']:
                 self.stdout.write(

--- a/edumanage/management/commands/fetch_kml.py
+++ b/edumanage/management/commands/fetch_kml.py
@@ -22,6 +22,7 @@ from django.core.management.base import BaseCommand
 import time
 from django.conf import settings
 from django.core.cache import cache
+from django.utils import six
 from xml.etree import ElementTree
 import json
 import bz2
@@ -73,5 +74,8 @@ class Command(BaseCommand):
                     }
                 )
         points = json.dumps(point_list)
+        if six.PY3:
+            # python3: convert string as bytestring
+            points = points.encode('utf-8')
         cache.set('points', bz2.compress(points), 60 * 3600 * 24)
         return True

--- a/edumanage/management/commands/fetch_kml.py
+++ b/edumanage/management/commands/fetch_kml.py
@@ -27,11 +27,6 @@ from xml.etree import ElementTree
 import json
 import bz2
 
-try:
-    from urllib.request import urlretrieve
-except ImportError:
-    from urllib import urlretrieve
-
 
 class Command(BaseCommand):
     args = ''
@@ -47,7 +42,7 @@ class Command(BaseCommand):
         eduroam_kml_url = "%s?gmaprnd=%s" % (eduroam_kml_url, rnd)
         write('Fetching data from %s...\n'%eduroam_kml_url)
         file = settings.KML_FILE
-        urlretrieve(eduroam_kml_url, file)
+        six.moves.urllib.request.urlretrieve(eduroam_kml_url, file)
         write('Done fetching!\n')
         write('Updating cache\n')
         self.refresh_cache(file)

--- a/edumanage/management/commands/fetch_kml.py
+++ b/edumanage/management/commands/fetch_kml.py
@@ -21,11 +21,15 @@
 from django.core.management.base import BaseCommand
 import time
 from django.conf import settings
-import urllib
 from django.core.cache import cache
 from xml.etree import ElementTree
 import json
 import bz2
+
+try:
+    from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlretrieve
 
 
 class Command(BaseCommand):
@@ -42,7 +46,7 @@ class Command(BaseCommand):
         eduroam_kml_url = "%s?gmaprnd=%s" % (eduroam_kml_url, rnd)
         write('Fetching data from %s...\n'%eduroam_kml_url)
         file = settings.KML_FILE
-        urllib.urlretrieve(eduroam_kml_url, file)
+        urlretrieve(eduroam_kml_url, file)
         write('Done fetching!\n')
         write('Updating cache\n')
         self.refresh_cache(file)

--- a/edumanage/management/commands/importcsv.py
+++ b/edumanage/management/commands/importcsv.py
@@ -47,14 +47,14 @@ class Command(BaseCommand):
         try:
             csvname = sys.argv[2]
         except IndexError:
-            print _('Error in usage. See help')
+            print(_('Error in usage. See help'))
             sys.exit(1)
 
         count = 0
         with open(csvname, 'rb') as f:
             reader = csv.reader(f)
             for row in reader:
-                print row
+                print(row)
                 (
                     username,
                     password,
@@ -79,8 +79,8 @@ class Command(BaseCommand):
                     )
                     monlocalauthnparams.save()
                 except InstRealm.DoesNotExist:
-                    print "Realm %s does not exit" % realm
+                    print("Realm %s does not exit" % realm)
 
-                print 'OK: realm %s' % (realm)
+                print('OK: realm %s' % (realm))
                 count += 1
-            print 'Total ' + str(count)
+            print('Total ' + str(count))

--- a/edumanage/management/commands/parse_institution_xml.py
+++ b/edumanage/management/commands/parse_institution_xml.py
@@ -20,6 +20,7 @@
 # SOFTWARE.
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
+from django.utils import six
 from edumanage.models import *
 from lxml.etree import parse
 import argparse
@@ -119,7 +120,7 @@ schema.''')
         self.stdout.write_maybe('%s %s: %s' %
                                 (created_or_found,
                                  type_str(object_tuple[0]),
-                                unicode(object_tuple[0])))
+                                six.text_type(object_tuple[0])))
         return object_tuple
 
     def parse_and_create_url(self, relobj, element):
@@ -146,7 +147,7 @@ schema.''')
         self.stdout.write_maybe('%s %s: %s' %
                                 ('Created' if obj_created else 'Found',
                                  type_str(obj),
-                                unicode(obj)))
+                                six.text_type(obj)))
         return obj
 
     def parse_and_create_instrealm(self, institution_obj, element):
@@ -162,7 +163,7 @@ schema.''')
         self.stdout.write_maybe('%s %s: %s' %
                                 ('Created' if object_tuple[1] else 'Found',
                                  type_str(object_tuple[0]),
-                                unicode(object_tuple[0])))
+                                six.text_type(object_tuple[0])))
         return object_tuple
 
     def parse_and_create_contact(self, relobj, element):
@@ -197,7 +198,7 @@ schema.''')
         self.stdout.write_maybe('%s %s: %s' %
                                 ('Created' if obj_created else 'Found',
                                  type_str(obj),
-                                unicode(obj)))
+                                six.text_type(obj)))
         return obj
 
     def parse_and_create_serviceloc(self, instobj, element):
@@ -288,7 +289,7 @@ schema.''')
         self.stdout.write_maybe('%s %s: %s' %
                                 ('Created' if obj_created else 'Found',
                                  type_str(obj),
-                                unicode(obj)))
+                                six.text_type(obj)))
         for url_element in url_elements:
             self.parse_and_create_url(obj, url_element)
         contacts_new = []
@@ -303,7 +304,7 @@ schema.''')
         if len(contacts_add) > 0:
             self.stdout.write_maybe('Linked %s contacts: %s' % (
                 type_str(obj),
-                ' '.join([unicode(c) for c in contacts_add])
+                ' '.join([six.text_type(c) for c in contacts_add])
                 ))
         contacts_remove = set(contacts_db) - set(contacts_new)
         for c in contacts_remove:
@@ -312,7 +313,7 @@ schema.''')
         if len(contacts_remove) > 0:
             self.stdout.write_maybe('Removed %s contacts: %s' % (
                 type_str(obj),
-                ' '.join([unicode(c) for c in contacts_remove])
+                ' '.join([six.text_type(c) for c in contacts_remove])
                 ))
         return obj
 
@@ -380,7 +381,7 @@ schema.''')
             self.stdout.write_maybe('%s %s: %s' %
                                     ('Created',
                                      type_str(institution_obj),
-                                    unicode(institution_obj)))
+                                    six.text_type(institution_obj)))
         else:
             institution_obj = parameters['org_name'][0][0].content_object
             if institution_obj is None:
@@ -389,7 +390,7 @@ schema.''')
                     'are not associated with an institution (only tried the ' +
                     'first one)! This must be fixed (e.g. by removing ' +
                     'duplicate objects) before we can proceed.\n' +
-                    '\n'.join([unicode(x[0]) for x in parameters['org_name']])
+                    '\n'.join([six.text_type(x[0]) for x in parameters['org_name']])
                     )
             if not [institution_obj] * len(parameters['org_name']) == \
               [getattr(x[0], 'content_object')
@@ -399,12 +400,12 @@ schema.''')
                     'are not associated with the same institution. ' +
                     'This must be fixed (e.g. by removing duplicate objects) ' +
                     'before we can proceed.\n' +
-                    '\n'.join([unicode(x[0]) for x in parameters['org_name']])
+                    '\n'.join([six.text_type(x[0]) for x in parameters['org_name']])
                     )
             self.stdout.write_maybe('%s %s: %s' %
                                     ('Found',
                                      type_str(institution_obj),
-                                    unicode(institution_obj)))
+                                    six.text_type(institution_obj)))
 
         for idx, contact_element in enumerate(parameters['contact']):
             parameters['contact'][idx] = \
@@ -423,7 +424,7 @@ schema.''')
         self.stdout.write_maybe('%s %s: %s' %
                                 ('Created' if instdetails_created else 'Found',
                                  type_str(instdetails_obj),
-                                unicode(instdetails_obj)))
+                                six.text_type(instdetails_obj)))
 
         contacts_db = instdetails_obj.contact.all()
         contacts_add = set(parameters['contact']) - set(contacts_db)
@@ -432,7 +433,7 @@ schema.''')
         if len(contacts_add) > 0:
             self.stdout.write_maybe('Linked %s contacts: %s' % (
                 type_str(instdetails_obj),
-                ' '.join([unicode(c) for c in contacts_add])
+                ' '.join([six.text_type(c) for c in contacts_add])
                 ))
         contacts_remove = set(contacts_db) - set(parameters['contact'])
         for c in contacts_remove:
@@ -441,7 +442,7 @@ schema.''')
         if len(contacts_remove) > 0:
             self.stdout.write_maybe('Removed %s contacts: %s' % (
                 type_str(instdetails_obj),
-                ' '.join([unicode(c) for c in contacts_remove])
+                ' '.join([six.text_type(c) for c in contacts_remove])
                 ))
 
         for tag in ['info_URL', 'policy_URL']:

--- a/edumanage/management/commands/parse_institution_xml.py
+++ b/edumanage/management/commands/parse_institution_xml.py
@@ -72,7 +72,7 @@ schema.''')
                   ))
         try:
             self.nrorealm = Realm.objects.get(country=settings.NRO_COUNTRY_CODE)
-        except Realm.DoesNotExist, AttributeError:
+        except (Realm.DoesNotExist, AttributeError):
             raise CommandError('%s\n%s' % (
                   'Failed to get the Realm object',
             '''Before running this command, the following prerequisites must be met:

--- a/edumanage/migrations/0001_initial.py
+++ b/edumanage/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('cat_inst_id', models.PositiveIntegerField()),
-                ('url', models.CharField(help_text=b'Set to ACTIVE if institution has CAT profiles', max_length=255, null=True, blank=True)),
+                ('url', models.CharField(help_text='Set to ACTIVE if institution has CAT profiles', max_length=255, null=True, blank=True)),
                 ('cat_instance', models.CharField(max_length=50, choices=edumanage.models.get_choices_from_settings('CAT_INSTANCES'))),
                 ('ts', models.DateTimeField(auto_now=True)),
                 ('applier', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
@@ -29,9 +29,9 @@ class Migration(migrations.Migration):
             name='Contact',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('name', models.CharField(max_length=255, db_column=b'contact_name')),
-                ('email', models.CharField(max_length=80, db_column=b'contact_email')),
-                ('phone', models.CharField(max_length=80, db_column=b'contact_phone')),
+                ('name', models.CharField(max_length=255, db_column='contact_name')),
+                ('email', models.CharField(max_length=80, db_column='contact_email')),
+                ('phone', models.CharField(max_length=80, db_column='contact_phone')),
             ],
             options={
                 'verbose_name': 'Contact',
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
             name='Institution',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('ertype', models.PositiveIntegerField(db_column=b'type', choices=[(1, b'IdP only'), (2, b'SP only'), (3, b'IdP and SP')])),
+                ('ertype', models.PositiveIntegerField(db_column='type', choices=[(1, 'IdP only'), (2, 'SP only'), (3, 'IdP and SP')])),
             ],
         ),
         migrations.CreateModel(
@@ -80,7 +80,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('realm', models.CharField(max_length=160)),
-                ('instid', models.ForeignKey(verbose_name=b'Institution', to='edumanage.Institution')),
+                ('instid', models.ForeignKey(verbose_name='Institution', to='edumanage.Institution')),
             ],
             options={
                 'verbose_name': 'Institution Realm',
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
             name='InstRealmMon',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('mon_type', models.CharField(max_length=16, choices=[(b'localauthn', b'Institution provides account for the NRO to monitor the realm')])),
+                ('mon_type', models.CharField(max_length=16, choices=[('localauthn', 'Institution provides account for the NRO to monitor the realm')])),
                 ('realm', models.ForeignKey(to='edumanage.InstRealm')),
             ],
             options={
@@ -103,18 +103,18 @@ class Migration(migrations.Migration):
             name='InstServer',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('ertype', models.PositiveIntegerField(db_column=b'type', choices=[(1, b'IdP only'), (2, b'SP only'), (3, b'IdP and SP')])),
+                ('ertype', models.PositiveIntegerField(db_column='type', choices=[(1, 'IdP only'), (2, 'SP only'), (3, 'IdP and SP')])),
                 ('name', models.CharField(help_text='Descriptive label', max_length=80, null=True, blank=True)),
-                ('addr_type', models.CharField(default=b'ipv4', max_length=16, choices=[(b'any', b'Default'), (b'ipv4', b'IPv4 only')])),
+                ('addr_type', models.CharField(default='ipv4', max_length=16, choices=[('any', 'Default'), ('ipv4', 'IPv4 only')])),
                 ('host', models.CharField(help_text='IP address | FQDN hostname', max_length=80)),
-                ('rad_pkt_type', models.CharField(default=b'auth+acct', max_length=48, null=True, blank=True, choices=[(b'auth', b'Handles Access-Request packets only'), (b'acct', b'Handles Accounting-Request packets only'), (b'auth+acct', b'Handles both Access-Request and Accounting-Request packets')])),
+                ('rad_pkt_type', models.CharField(default='auth+acct', max_length=48, null=True, blank=True, choices=[('auth', 'Handles Access-Request packets only'), ('acct', 'Handles Accounting-Request packets only'), ('auth+acct', 'Handles both Access-Request and Accounting-Request packets')])),
                 ('auth_port', models.PositiveIntegerField(default=1812, help_text='Default for RADIUS: 1812', null=True, blank=True)),
                 ('acct_port', models.PositiveIntegerField(default=1813, help_text='Default for RADIUS: 1813', null=True, blank=True)),
                 ('status_server', models.BooleanField(help_text='Do you accept Status-Server requests?')),
                 ('secret', models.CharField(max_length=80)),
-                ('proto', models.CharField(default=b'radius', max_length=12, choices=[(b'radius', b'traditional RADIUS over UDP')])),
+                ('proto', models.CharField(default='radius', max_length=12, choices=[('radius', 'traditional RADIUS over UDP')])),
                 ('ts', models.DateTimeField(auto_now=True)),
-                ('instid', models.ManyToManyField(default=b'none', related_name='servers', to='edumanage.Institution')),
+                ('instid', models.ManyToManyField(default='none', related_name='servers', to='edumanage.Institution')),
             ],
             options={
                 'verbose_name': 'Institution Server',
@@ -125,10 +125,10 @@ class Migration(migrations.Migration):
             name='MonLocalAuthnParam',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('eap_method', models.CharField(max_length=16, choices=[(b'PEAP', b'EAP-PEAP'), (b'TTLS', b'EAP-TTLS')])),
-                ('phase2', models.CharField(max_length=16, choices=[(b'PAP', b'PAP'), (b'CHAP', b'CHAP'), (b'MS-CHAPv2', b'MS-CHAPv2')])),
+                ('eap_method', models.CharField(max_length=16, choices=[('PEAP', 'EAP-PEAP'), ('TTLS', 'EAP-TTLS')])),
+                ('phase2', models.CharField(max_length=16, choices=[('PAP', 'PAP'), ('CHAP', 'CHAP'), ('MS-CHAPv2', 'MS-CHAPv2')])),
                 ('username', models.CharField(max_length=36)),
-                ('passwp', models.CharField(max_length=80, db_column=b'pass')),
+                ('passwp', models.CharField(max_length=80, db_column='pass')),
                 ('instrealmmonid', models.OneToOneField(to='edumanage.InstRealmMon')),
             ],
             options={
@@ -144,7 +144,7 @@ class Migration(migrations.Migration):
                 ('host', models.CharField(help_text='IP address | FQDN hostname', max_length=80)),
                 ('status_server', models.BooleanField()),
                 ('secret', models.CharField(max_length=80)),
-                ('proto', models.CharField(max_length=12, choices=[(b'radius', b'traditional RADIUS over UDP')])),
+                ('proto', models.CharField(max_length=12, choices=[('radius', 'traditional RADIUS over UDP')])),
                 ('ts', models.DateTimeField(auto_now=True)),
                 ('instrealmmonid', models.ForeignKey(to='edumanage.InstRealmMon')),
             ],
@@ -206,7 +206,7 @@ class Migration(migrations.Migration):
                 ('address_street', models.CharField(max_length=96)),
                 ('address_city', models.CharField(max_length=64)),
                 ('SSID', models.CharField(max_length=16)),
-                ('enc_level', edumanage.models.MultiSelectField(blank=True, max_length=64, null=True, choices=[(b'WPA/TKIP', b'WPA-TKIP'), (b'WPA/AES', b'WPA-AES'), (b'WPA2/TKIP', b'WPA2-TKIP'), (b'WPA2/AES', b'WPA2-AES')])),
+                ('enc_level', edumanage.models.MultiSelectField(blank=True, max_length=64, null=True, choices=[('WPA/TKIP', 'WPA-TKIP'), ('WPA/AES', 'WPA-AES'), ('WPA2/TKIP', 'WPA2-TKIP'), ('WPA2/AES', 'WPA2-AES')])),
                 ('port_restrict', models.BooleanField()),
                 ('transp_proxy', models.BooleanField()),
                 ('IPv6', models.BooleanField()),
@@ -215,7 +215,7 @@ class Migration(migrations.Migration):
                 ('wired', models.BooleanField()),
                 ('ts', models.DateTimeField(auto_now=True)),
                 ('contact', models.ManyToManyField(to='edumanage.Contact', blank=True)),
-                ('institutionid', models.ForeignKey(verbose_name=b'Institution', to='edumanage.Institution')),
+                ('institutionid', models.ForeignKey(verbose_name='Institution', to='edumanage.Institution')),
             ],
             options={
                 'verbose_name': 'Service Location',
@@ -226,9 +226,9 @@ class Migration(migrations.Migration):
             name='URL_i18n',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('url', models.CharField(max_length=180, db_column=b'URL')),
+                ('url', models.CharField(max_length=180, db_column='URL')),
                 ('lang', models.CharField(max_length=5, choices=edumanage.models.get_choices_from_settings('URL_NAME_LANGS'))),
-                ('urltype', models.CharField(max_length=10, db_column=b'type', choices=[(b'info', b'Info'), (b'policy', b'Policy')])),
+                ('urltype', models.CharField(max_length=10, db_column='type', choices=[('info', 'Info'), ('policy', 'Policy')])),
                 ('object_id', models.PositiveIntegerField(null=True, blank=True)),
                 ('content_type', models.ForeignKey(blank=True, to='contenttypes.ContentType', null=True)),
             ],

--- a/edumanage/models.py
+++ b/edumanage/models.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import fields
 from django.utils.text import capfirst
+from django.utils import six
 from django.core import exceptions
 from django.conf import settings
 from django import forms
@@ -61,7 +62,7 @@ class MultiSelectField(models.Field):
         return value
 
     def get_db_prep_value(self, value, connection=None, prepared=False):
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             return value
         elif isinstance(value, list):
             return ",".join(value)

--- a/edumanage/models.py
+++ b/edumanage/models.py
@@ -9,6 +9,7 @@ from django.core import exceptions
 from django.conf import settings
 from django import forms
 from django.core.exceptions import ValidationError
+from django.utils.encoding import python_2_unicode_compatible
 
 
 def get_choices_from_settings(setting):
@@ -125,6 +126,7 @@ RADTYPES = (
 )
 
 
+@python_2_unicode_compatible
 class Name_i18n(models.Model):
     '''
     Name in a particular language
@@ -136,7 +138,7 @@ class Name_i18n(models.Model):
     object_id = models.PositiveIntegerField(blank=True, null=True)
     content_object = fields.GenericForeignKey('content_type', 'object_id')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta:
@@ -144,6 +146,7 @@ class Name_i18n(models.Model):
         verbose_name_plural = "Names (i18n)"
 
 
+@python_2_unicode_compatible
 class Contact(models.Model):
     '''
     Contact
@@ -153,7 +156,7 @@ class Contact(models.Model):
     email = models.CharField(max_length=80, db_column='contact_email')
     phone = models.CharField(max_length=80, db_column='contact_phone')
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s <%s> (%s)' % (self.name, self.email, self.phone)
 
     class Meta:
@@ -161,11 +164,12 @@ class Contact(models.Model):
         verbose_name_plural = "Contacts"
 
 
+@python_2_unicode_compatible
 class InstitutionContactPool(models.Model):
     contact = models.OneToOneField(Contact)
     institution = models.ForeignKey("Institution")
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s:%s" %(self.contact, self.institution)
 
     class Meta:
@@ -173,6 +177,7 @@ class InstitutionContactPool(models.Model):
         verbose_name_plural = "Instutution Contacts (Pool)"
 
 
+@python_2_unicode_compatible
 class URL_i18n(models.Model):
     '''
     URL of a particular type in a particular language
@@ -193,10 +198,11 @@ class URL_i18n(models.Model):
         verbose_name = "Url (i18n)"
         verbose_name_plural = "Urls (i18n)"
 
-    def __unicode__(self):
+    def __str__(self):
         return self.url
 
 
+@python_2_unicode_compatible
 class InstRealm(models.Model):
     '''
     Realm of an IdP Institution
@@ -210,13 +216,14 @@ class InstRealm(models.Model):
         verbose_name = "Institution Realm"
         verbose_name_plural = "Institutions' Realms"
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % self.realm
 
     def get_servers(self):
         return ",".join(["%s" % x for x in self.proxyto.all()])
 
 
+@python_2_unicode_compatible
 class InstServer(models.Model):
     '''
     Server of an Institution
@@ -250,7 +257,7 @@ class InstServer(models.Model):
         verbose_name = "Institution Server"
         verbose_name_plural = "Institutions' Servers"
 
-    def __unicode__(self):
+    def __str__(self):
         return _('Server: %(servername)s, Type: %(ertype)s') % {
             # but name is many-to-many from institution
             # 'inst': self.instid,
@@ -282,6 +289,7 @@ class InstServer(models.Model):
                     )
 
 
+@python_2_unicode_compatible
 class InstRealmMon(models.Model):
     '''
     Realm of an IdP Institution to be monitored
@@ -300,9 +308,9 @@ class InstRealmMon(models.Model):
         verbose_name = "Institution Monitored Realm"
         verbose_name_plural = "Institution Monitored Realms"
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s-%s" % (self.realm.realm, self.mon_type)
-#    def __unicode__(self):
+#    def __str__(self):
 #        return _('Institution: %(inst)s, Monitored Realm: %(monrealm)s, Monitoring Type: %(montype)s') % {
 #        # but name is many-to-many from institution
 #            'inst': self.instid.name,
@@ -311,6 +319,7 @@ class InstRealmMon(models.Model):
 #            }
 
 
+@python_2_unicode_compatible
 class MonProxybackClient(models.Model):
     '''
     Server of an Institution that will be proxying back requests for a monitored realm
@@ -338,7 +347,7 @@ class MonProxybackClient(models.Model):
         verbose_name = "Institution Proxyback Client"
         verbose_name_plural = "Institution Proxyback Clients"
 
-    def __unicode__(self):
+    def __str__(self):
         return _('Monitored Realm: %(monrealm)s, Proxyback Client: %(servername)s') % {
             # but name is many-to-many from institution
             'monrealm': self.instrealmmonid.realm,
@@ -346,6 +355,7 @@ class MonProxybackClient(models.Model):
         }
 
 
+@python_2_unicode_compatible
 class MonLocalAuthnParam(models.Model):
     '''
     Parameters for an old-style monitored realm
@@ -381,7 +391,7 @@ class MonLocalAuthnParam(models.Model):
         verbose_name = "Monitored Realm (local authn)"
         verbose_name_plural = "Monitored Realms (local authn)"
 
-    def __unicode__(self):
+    def __str__(self):
         return _('Monitored Realm: %(monrealm)s, EAP Method: %(eapmethod)s, Phase 2: %(phase2)s, Username: %(username)s') % {
             # but name is many-to-many from institution
             'monrealm': self.instrealmmonid.realm,
@@ -391,6 +401,7 @@ class MonLocalAuthnParam(models.Model):
         }
 
 
+@python_2_unicode_compatible
 class ServiceLoc(models.Model):
     '''
     Service Location of an SP/IdPSP Institution
@@ -428,7 +439,7 @@ class ServiceLoc(models.Model):
         verbose_name = "Service Location"
         verbose_name_plural = "Service Locations"
 
-    def __unicode__(self):
+    def __str__(self):
         return _('Institution: %(inst)s, Service Location: %(locname)s') % {
             # but name is many-to-many from institution
             'inst': self.institutionid,
@@ -449,6 +460,7 @@ class ServiceLoc(models.Model):
     get_name.short_description = 'Location Name'
 
 
+@python_2_unicode_compatible
 class Institution(models.Model):
     '''
     Institution
@@ -458,7 +470,7 @@ class Institution(models.Model):
     org_name = fields.GenericRelation(Name_i18n)
     ertype = models.PositiveIntegerField(choices=ERTYPES, db_column='type')
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s" % ', '.join([i.name for i in self.org_name.all()])
 
     def get_name(self, lang=None):
@@ -488,6 +500,7 @@ class Institution(models.Model):
         return ids
 
 
+@python_2_unicode_compatible
 class InstitutionDetails(models.Model):
     '''
     Institution Details
@@ -514,7 +527,7 @@ class InstitutionDetails(models.Model):
         verbose_name = "Institutions' Details"
         verbose_name_plural = "Institution Details"
 
-    def __unicode__(self):
+    def __str__(self):
         return _('Institution: %(inst)s, Type: %(ertype)s') % {
             # but name is many-to-many from institution
             'inst': ', '.join([i.name for i in self.institution.org_name.all()]),
@@ -526,6 +539,7 @@ class InstitutionDetails(models.Model):
     get_inst_name.short_description = "Institution Name"
 
 
+@python_2_unicode_compatible
 class Realm(models.Model):
     '''
     Realm
@@ -545,7 +559,7 @@ class Realm(models.Model):
         verbose_name = "Realm"
         verbose_name_plural = "Realms"
 
-    def __unicode__(self):
+    def __str__(self):
         return _('Country: %(country)s, NRO: %(orgname)s') % {
             # but name is many-to-many from institution
             'orgname': ', '.join([i.name for i in self.org_name.all()]),
@@ -565,6 +579,7 @@ class Realm(models.Model):
 
 
 # TODO: this represents a *database view* "realm_data", find a better way to write it
+@python_2_unicode_compatible
 class RealmData(models.Model):
     '''
     Realm statistics
@@ -586,7 +601,7 @@ class RealmData(models.Model):
     # db: select greatest(max(realm.ts), max(institution.ts)) as ts from institution, realm where institution.realmid == realm.realmid
     ts = models.DateTimeField(editable=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return _('Country: %(country)s, NRO: %(orgname)s, Institutions: %(inst)s, IdPs: %(idp)s, SPs: %(sp)s, IdPSPs: %(idpsp)s, Users: %(numuser)s, Identities: %(numid)s') % {
             # but name is many-to-many from institution
             'orgname': self.org_name,
@@ -600,6 +615,7 @@ class RealmData(models.Model):
         }
 
 
+@python_2_unicode_compatible
 class CatEnrollment(models.Model):
     ''' eduroam CAT enrollment '''
 
@@ -615,7 +631,7 @@ class CatEnrollment(models.Model):
     class Meta:
         unique_together = ['inst', 'cat_instance']
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s: %s" % (self.cat_inst_id, ', '.join([i.name for i in self.inst.org_name.all()]))
 
     def cat_active(self):

--- a/edumanage/templatetags/tolocale.py
+++ b/edumanage/templatetags/tolocale.py
@@ -7,7 +7,7 @@ def tolocale(parser, token):
     try:
         tag_name, objtrans, format_string = token.split_contents()
     except ValueError:
-        raise template.TemplateSyntaxError, "%r tag requires exactly two arguments" % token.contents.split()[0]
+        raise template.TemplateSyntaxError("%r tag requires exactly two arguments" % token.contents.split()[0])
     return CurrentLocaleNode(objtrans, format_string)
 
 

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -6,7 +6,7 @@ import math
 import datetime
 from xml.etree import ElementTree
 import locale
-from localectxmgr import setlocale
+from edumanage.localectxmgr import setlocale
 import requests
 
 from django.shortcuts import redirect, render

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -31,6 +31,7 @@ from django.contrib import messages
 from django.db.models import Max
 from django.views.decorators.cache import never_cache
 from django.utils.translation import ugettext as _
+from django.utils import six
 from accounts.models import User
 from django.core.cache import cache
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -2582,7 +2583,8 @@ def to_xml(ele, encoding="UTF-8"):
     Convert and return the XML for an *ele*
     (:class:`~xml.etree.ElementTree.Element`)
     with specified *encoding*.'''
-    xml = ElementTree.tostring(ele, encoding)
+    # on python3, we need to get a string, not bytestring - so if requesting unicode, request it as "unicode"
+    xml = ElementTree.tostring(ele, "unicode" if six.PY3 and encoding.lower()=="utf-8" else encoding)
     return xml if xml.startswith('<?xml') else '<?xml version="1.0" encoding="%s"?>%s' % (encoding, xml)
 
 

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1699,9 +1699,8 @@ def participants(request):
         if i.get_active_cat_enrl(cat_instance):
             cat_exists = True
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
-        dets.sort(cmp=locale.strcoll,
-                  key=lambda x: unicode(x.institution.
-                                        get_name(lang=request.LANGUAGE_CODE)))
+        dets.sort(key=lambda x: locale.strxfrm(
+            unicode(x.institution.get_name(lang=request.LANGUAGE_CODE))))
     return render(
         request,
         'front/participants.html',
@@ -1730,9 +1729,8 @@ def connect(request):
             # may be more
             dets_cat[i.pk] = catids[0]
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
-        dets.sort(cmp=locale.strcoll,
-                  key=lambda x: unicode(x.institution.
-                                        get_name(lang=request.LANGUAGE_CODE)))
+        dets.sort(key=lambda x: locale.strxfrm(
+            unicode(x.institution.get_name(lang=request.LANGUAGE_CODE))))
     if settings_dict_get('CAT_AUTH', cat_instance) is None:
         cat_exists = False
         cat_api_direct = None

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1943,6 +1943,10 @@ def getPoints():
     points = cache.get('points')
     if points:
         points = bz2.decompress(points)
+        if six.PY3:
+            # decode from bytes to strings
+            # (done automatically in json.loads on python 3.6+)
+            points = points.decode('utf-8')
         return json.loads(points)
     else:
         point_list = []
@@ -1964,7 +1968,8 @@ def getPoints():
                 point_list.append(marker)
         points = json.dumps(point_list)
         # make timeout configurable
-        cache.set('points', bz2.compress(points), 60 * 60 * 24)
+        # encode points into bytestring on python 3, keep as-is otherwise
+        cache.set('points', bz2.compress(points.encode('utf-8') if six.PY3 else points), 60 * 60 * 24)
         return json.loads(points)
 
 

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1700,7 +1700,7 @@ def participants(request):
             cat_exists = True
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
         dets.sort(key=lambda x: locale.strxfrm(
-            six.text_type(x.institution.get_name(lang=request.LANGUAGE_CODE))))
+            str(x.institution.get_name(lang=request.LANGUAGE_CODE))))
     return render(
         request,
         'front/participants.html',
@@ -1730,7 +1730,7 @@ def connect(request):
             dets_cat[i.pk] = catids[0]
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
         dets.sort(key=lambda x: locale.strxfrm(
-            six.text_type(x.institution.get_name(lang=request.LANGUAGE_CODE))))
+            str(x.institution.get_name(lang=request.LANGUAGE_CODE))))
     if settings_dict_get('CAT_AUTH', cat_instance) is None:
         cat_exists = False
         cat_api_direct = None

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -186,7 +186,7 @@ def institutions(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     dict['institution'] = inst.pk
@@ -210,7 +210,7 @@ def add_institution_details(request, institution_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
 
@@ -293,7 +293,7 @@ def services(request, service_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -355,7 +355,7 @@ def add_services(request, service_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -585,7 +585,7 @@ def add_server(request, server_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -662,7 +662,7 @@ def cat_enroll(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -844,7 +844,7 @@ def add_realm(request, realm_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -963,7 +963,7 @@ def contacts(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -994,7 +994,7 @@ def add_contact(request, contact_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1130,7 +1130,7 @@ def instrealmmon(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1156,7 +1156,7 @@ def add_instrealmmon(request, instrealmmon_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1266,7 +1266,7 @@ def add_monlocauthpar(request, instrealmmon_pk, monlocauthpar_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1394,7 +1394,7 @@ def adduser(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__unicode__ = inst.get_name(request.LANGUAGE_CODE)
+        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
 

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1700,7 +1700,7 @@ def participants(request):
             cat_exists = True
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
         dets.sort(key=lambda x: locale.strxfrm(
-            unicode(x.institution.get_name(lang=request.LANGUAGE_CODE))))
+            six.text_type(x.institution.get_name(lang=request.LANGUAGE_CODE))))
     return render(
         request,
         'front/participants.html',
@@ -1730,7 +1730,7 @@ def connect(request):
             dets_cat[i.pk] = catids[0]
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
         dets.sort(key=lambda x: locale.strxfrm(
-            unicode(x.institution.get_name(lang=request.LANGUAGE_CODE))))
+            six.text_type(x.institution.get_name(lang=request.LANGUAGE_CODE))))
     if settings_dict_get('CAT_AUTH', cat_instance) is None:
         cat_exists = False
         cat_api_direct = None
@@ -2465,7 +2465,7 @@ def adminlist(request):
         u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
         for m in u.email.split(';')
     ]
-    data.sort(key=lambda d: unicode(d[0]))
+    data.sort(key=lambda d: six.text_type(d[0]))
     resp_body = ""
     for (foreas, onoma, email) in data:
         resp_body += u'{email}\t{onoma}'.format(

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -5,6 +5,7 @@ import bz2
 import math
 import datetime
 from xml.etree import ElementTree
+import itertools
 import locale
 from edumanage.localectxmgr import setlocale
 import requests
@@ -2669,7 +2670,4 @@ def settings_dict_get(setting, *keys, **opts):
 
 # utility function to merge two dictionaries
 def merge_dicts(dict1, dict2):
-    d = {}
-    for k, v in dict1.items() + dict2.items():
-        d[k] = v
-    return d
+    return dict(itertools.chain(dict1.items(), dict2.items()))

--- a/extras/freeradius-proxy.tpl
+++ b/extras/freeradius-proxy.tpl
@@ -10,13 +10,10 @@ def realm_regex(text):
         return '"~%s$"' % text
     else:
         return text
-def wildcard_realm_least_precedence(a, b):
-    if a.find('*.') == 0 and b.find('*.') != 0:
-        return -1
-    elif b.find('*.') == 0 and a.find('*.') != 0:
-        return 1
-    else:
-        return 0
+def wildcard_realm_least_precedence(key):
+    return '~' + key \
+        if (key.find('*.') == 0) else \
+        key
 def deduplicated_list(seq):
     seen = set()
     return [x for x in seq if not (x in seen or seen.add(x))]
@@ -60,7 +57,7 @@ servers[srv]['seen'] = True
 %>\
 % endif
 % endfor
-% for realm in sorted([r for r in inst['realms'] if 'proxy_to' in inst['realms'][r]], cmp=wildcard_realm_least_precedence, reverse=True):
+% for realm in sorted([r for r in inst['realms'] if 'proxy_to' in inst['realms'][r]], key=wildcard_realm_least_precedence):
 <%
 realm_servers = {}
 for t in ['auth', 'acct', 'auth+acct']:

--- a/extras/radsecproxy.tpl
+++ b/extras/radsecproxy.tpl
@@ -10,13 +10,10 @@ def realm_regex(text):
         return '"/@%s$"' % text
     else:
         return text
-def wildcard_realm_least_precedence(a, b):
-    if a.find('*.') == 0 and b.find('*.') != 0:
-        return -1
-    elif b.find('*.') == 0 and a.find('*.') != 0:
-        return 1
-    else:
-        return 0
+def wildcard_realm_least_precedence(key):
+    return '~' + key \
+        if (key.find('*.') == 0) else \
+        key
 def deduplicated_list(seq):
     seen = set()
     return [x for x in seq if not (x in seen or seen.add(x))]
@@ -109,7 +106,7 @@ servers[srv]['seen'] = True
 %>\
 % endif
 % endfor
-% for realm in sorted([r for r in inst['realms'] if 'proxy_to' in inst['realms'][r]], cmp=wildcard_realm_least_precedence, reverse=True):
+% for realm in sorted([r for r in inst['realms'] if 'proxy_to' in inst['realms'][r]], key=wildcard_realm_least_precedence):
 realm ${realm | realm_regex} {
 % for srv in inst['realms'][realm]['proxy_to']:
 % if servers[srv]['rad_pkt_type'] in ('auth', 'auth+acct'):

--- a/extras/servdata_consumer.py
+++ b/extras/servdata_consumer.py
@@ -14,6 +14,7 @@ except ImportError:
 import requests
 from mako.template import Template
 from mako.lookup import TemplateLookup
+from django.utils import six
 
 SETTINGS = {
     "template_directory" : "/etc/djnro_servdata",
@@ -157,7 +158,11 @@ directory (may be used more than once) [default: %s]"""
     for t in SETTINGS["templates"]:
         to = t.replace('-', '_')
         if getattr(opts, to, None) is not None:
-            getattr(opts, to).write(sw.render_tpl(t))
+            rendered_template = sw.render_tpl(t)
+            if six.PY3:
+                # mako.template.Template.render returned bytestring, convert to str
+                rendered_template = rendered_template.decode('utf-8')
+            getattr(opts, to).write(rendered_template)
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ ipaddress==1.0.22
 social-auth-app-django>=3.1.0,<4.0
 social-auth-core>=3.0.0,<4.0
 requests==2.9.1
-wsgiref==0.1.2
 lxml>=2.3.2
 PyYAML>=3.10,<4.0a
 django-dont-vary-on>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=1.11,<2.0
 argparse>=1.2.1
 django-registration==2.0.4
 django-tinymce>=2.3.0,<3.0a
-ipaddr==2.1.11
+ipaddress==1.0.22
 social-auth-app-django>=3.1.0,<4.0
 social-auth-core>=3.0.0,<4.0
 requests==2.9.1


### PR DESCRIPTION
Hi @zmousm ,

This is my first cut of the Python3 overhaul.

I was in principle following the general 2-3 porting guidelines (preserving 2 compatibility).

And the Django porting documentation, https://docs.djangoproject.com/en/1.11/topics/python3/

We are at the right spot to do the porting: the first Django LTS to support Python3, and the last to still support Python2...

I've documented the rationale for changes done in the commit messages - hope all is clear.

I got the code to the point where everything works with Python3 (tried all URLs, management commands) and still also works under Python2.

Please let me know what you think about it.

Cheers,
Vlad

PS: And thanks for the hint on the sorting issue - I've cherry-picked your commit and included it here..
