### PR TITLE
settings: use https for upstream KML file

### DIFF
--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -239,7 +239,7 @@ LOGIN_URL = '/manage/login/'
 
 KML_FILE = os.path.join(PROJECT_DIR, 'all.kml')
 
-EDUROAM_KML_URL = 'http://monitor.eduroam.org/kml/all.kml'
+EDUROAM_KML_URL = 'https://monitor.eduroam.org/kml/all.kml'
 
 # Request session cookies to be marked as secure
 SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
Hi @zmousm ,

This is a trivial change ... but to be sure I'm not overlooking something, I'm doing it through a PR.

I can see that monitor.eduroam.org responds to both http and https and serves the same content.

I've checked and the https URL works - just checking I'm not overlooking something, in case there was a reason for using plain http.

Does this look to you OK to merge?

Cheers,
Vlad