### PR TITLE
Python3 fixes - CAT enrollment

### DIFF
--- a/utils/cat_helper.py
+++ b/utils/cat_helper.py
@@ -94,7 +94,7 @@ class CatQuery(object):
                     params[id]['LANG'] = kwargs[k]
                 else:
                     params[id]['VALUE'] = kwargs[k]
-        return filter(None, params)
+        return list(filter(None, params))
 
     """ Add an administrator into an institution """
     def adminadd(self, kwargs):

--- a/utils/cat_helper.py
+++ b/utils/cat_helper.py
@@ -80,7 +80,7 @@ class CatQuery(object):
     to the uglify() method at https://github.com/GEANT/CAT/blob/master/web/lib/admin/API.php
     '''
     def deuglify(self, kwargs):
-        params = [None]*(len(kwargs)/2);
+        params = [None]*(len(kwargs)//2);
         for k in sorted(kwargs, key=string_split_by_numbers):
             m = re.search(r"\[S(\d+)", k);
             id = 0


### PR DESCRIPTION
Two trivial fixes for Python3 support - in CAT integration.  Which did not get the full testing coverage in #64 ... wasn't easy to test.

Tested now as we are running on Python3 in production.