### PR TITLE
Fixes for get_name() and locale-driven sorting

### DIFF
--- a/edumanage/management/commands/contacts.py
+++ b/edumanage/management/commands/contacts.py
@@ -6,8 +6,6 @@ warnings.simplefilter("ignore", DeprecationWarning)
 import sys
 import locale
 import codecs
-# sort greek utf-8 properly
-locale.setlocale(locale.LC_COLLATE, ('el_GR', 'UTF-8'))
 # Printing unicode: WAS: https://wiki.python.org/moin/PrintFails
 # But now rather follow:
 #    https://docs.djangoproject.com/en/1.9/howto/custom-management-commands/#management-commands-and-locales
@@ -18,6 +16,8 @@ from optparse import make_option
 from django.core.management.base import BaseCommand
 from django.utils import six
 from accounts.models import User
+from django.utils.translation import get_language, to_locale, ugettext as _
+from edumanage.localectxmgr import setlocale
 
 
 class Command(BaseCommand):
@@ -39,16 +39,16 @@ class Command(BaseCommand):
         users = User.objects.all()
         if not options['maillist']:
             self.stdout.write(
-                u'"%s","%s","%s"' % (
-                    u"Φορέας",
-                    u"Διαχειριστής",
+                u'{},{},{}'.format(
+                    _('Institution'),
+                    _('Administrator'),
                     "email"
                 )
                 + "\n"
             )
         data = [
             (
-                u.userprofile.institution.get_name('el'),
+                u.userprofile.institution.get_name(get_language()),
                 u.first_name + " " + u.last_name,
                 m
             ) for u in users if (
@@ -60,7 +60,9 @@ class Command(BaseCommand):
             if not six.PY3:
                 string = string.encode('utf-8')
             return locale.strxfrm(string)
-        data.sort(key=lambda d: compat_strxfrm(d[0]))
+        with setlocale((to_locale(get_language()), 'UTF-8'),
+                       locale.LC_COLLATE):
+            data.sort(key=lambda d: compat_strxfrm(d[0]))
         for (foreas, onoma, email) in data:
             if options['maillist']:
                 self.stdout.write(

--- a/edumanage/management/commands/contacts.py
+++ b/edumanage/management/commands/contacts.py
@@ -14,10 +14,9 @@ import codecs
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
-from django.utils import six
 from accounts.models import User
 from django.utils.translation import get_language, to_locale, ugettext as _
-from edumanage.localectxmgr import setlocale
+from utils.locale import setlocale, compat_strxfrm
 
 
 class Command(BaseCommand):
@@ -56,10 +55,6 @@ class Command(BaseCommand):
                 and u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
             ) for m in u.email.split(';')
         ]
-        def compat_strxfrm(string):
-            if not six.PY3:
-                string = string.encode('utf-8')
-            return locale.strxfrm(string)
         with setlocale((to_locale(get_language()), 'UTF-8'),
                        locale.LC_COLLATE):
             data.sort(key=lambda d: compat_strxfrm(d[0]))

--- a/edumanage/models.py
+++ b/edumanage/models.py
@@ -146,6 +146,20 @@ class Name_i18n(models.Model):
         verbose_name = "Name (i18n)"
         verbose_name_plural = "Names (i18n)"
 
+    @staticmethod
+    def get_name_factory(reverse_accessor):
+        def get_name(self, lang=None):
+            manager = getattr(self, reverse_accessor)
+            def all_names():
+                return ', '.join([n.name for n in manager.all()])
+            if not lang:
+                return all_names()
+            try:
+                return manager.get(lang=lang).name
+            except Name_i18n.DoesNotExist:
+                return all_names()
+        return get_name
+
 
 @python_2_unicode_compatible
 class Contact(models.Model):
@@ -448,16 +462,7 @@ class ServiceLoc(models.Model):
             'locname': self.get_name(),
         }
 
-    def get_name(self, lang=None):
-        name = ', '.join([i.name for i in self.loc_name.all()])
-        if not lang:
-            return name
-        else:
-            try:
-                name = self.loc_name.get(lang=lang)
-                return name
-            except Exception:
-                return name
+    get_name = Name_i18n.get_name_factory('loc_name')
     get_name.short_description = 'Location Name'
 
 
@@ -474,16 +479,7 @@ class Institution(models.Model):
     def __str__(self):
         return "%s" % ', '.join([i.name for i in self.org_name.all()])
 
-    def get_name(self, lang=None):
-        name = ', '.join([i.name for i in self.org_name.all()])
-        if not lang:
-            return name
-        else:
-            try:
-                name = self.org_name.get(lang=lang)
-                return name
-            except Exception:
-                return name
+    get_name = Name_i18n.get_name_factory('org_name')
 
     def get_active_cat_enrl(self, cat_instance='production'):
         urls = []
@@ -567,16 +563,7 @@ class Realm(models.Model):
             'country': self.country,
         }
 
-    def get_name(self, lang=None):
-        name = ', '.join([i.name for i in self.org_name.all()])
-        if not lang:
-            return name
-        else:
-            try:
-                name = self.org_name.get(lang=lang)
-                return name
-            except Exception:
-                return name
+    get_name = Name_i18n.get_name_factory('org_name')
 
 
 # TODO: this represents a *database view* "realm_data", find a better way to write it

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -186,7 +186,6 @@ def institutions(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     dict['institution'] = inst.pk
@@ -210,7 +209,6 @@ def add_institution_details(request, institution_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
 
@@ -293,7 +291,6 @@ def services(request, service_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -355,7 +352,6 @@ def add_services(request, service_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -585,7 +581,6 @@ def add_server(request, server_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -662,7 +657,6 @@ def cat_enroll(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -844,7 +838,6 @@ def add_realm(request, realm_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -963,7 +956,6 @@ def contacts(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -994,7 +986,6 @@ def add_contact(request, contact_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1130,7 +1121,6 @@ def instrealmmon(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1156,7 +1146,6 @@ def add_instrealmmon(request, instrealmmon_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1266,7 +1255,6 @@ def add_monlocauthpar(request, instrealmmon_pk, monlocauthpar_pk):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
     try:
@@ -1394,7 +1382,6 @@ def adduser(request):
     try:
         profile = user.userprofile
         inst = profile.institution
-        inst.__str__ = inst.get_name(request.LANGUAGE_CODE)
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
 

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -7,7 +7,6 @@ import datetime
 from xml.etree import ElementTree
 import itertools
 import locale
-from edumanage.localectxmgr import setlocale
 import requests
 
 from django.shortcuts import redirect, render
@@ -74,6 +73,7 @@ from django.utils.cache import (
 )
 from django_dont_vary_on.decorators import dont_vary_on
 from utils.cat_helper import CatQuery
+from utils.locale import setlocale, compat_strxfrm
 
 
 # Almost verbatim copy of django.views.i18n.set_language; however:
@@ -1686,7 +1686,7 @@ def participants(request):
         if i.get_active_cat_enrl(cat_instance):
             cat_exists = True
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
-        dets.sort(key=lambda x: locale.strxfrm(
+        dets.sort(key=lambda x: compat_strxfrm(
             x.institution.get_name(lang=request.LANGUAGE_CODE)))
     return render(
         request,
@@ -1716,7 +1716,7 @@ def connect(request):
             # may be more
             dets_cat[i.pk] = catids[0]
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
-        dets.sort(key=lambda x: locale.strxfrm(
+        dets.sort(key=lambda x: compat_strxfrm(
             x.institution.get_name(lang=request.LANGUAGE_CODE)))
     if settings_dict_get('CAT_AUTH', cat_instance) is None:
         cat_exists = False
@@ -2452,7 +2452,8 @@ def adminlist(request):
         u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
         for m in u.email.split(';')
     ]
-    data.sort(key=lambda d: d[0])
+    with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
+        data.sort(key=lambda d: compat_strxfrm(d[0]))
     resp_body = ""
     for (foreas, onoma, email) in data:
         resp_body += u'{email}\t{onoma}'.format(

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -2445,7 +2445,7 @@ def adminlist(request):
     users = User.objects.filter(userprofile__isnull=False,
                                 registrationprofile__isnull=False)
     data = [
-        (u.userprofile.institution.get_name('el'),
+        (u.userprofile.institution.get_name(request.LANGUAGE_CODE),
          u.first_name + " " + u.last_name,
          m)
         for u in users if

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1687,7 +1687,7 @@ def participants(request):
             cat_exists = True
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
         dets.sort(key=lambda x: locale.strxfrm(
-            str(x.institution.get_name(lang=request.LANGUAGE_CODE))))
+            x.institution.get_name(lang=request.LANGUAGE_CODE)))
     return render(
         request,
         'front/participants.html',
@@ -1717,7 +1717,7 @@ def connect(request):
             dets_cat[i.pk] = catids[0]
     with setlocale((request.LANGUAGE_CODE, 'UTF-8'), locale.LC_COLLATE):
         dets.sort(key=lambda x: locale.strxfrm(
-            str(x.institution.get_name(lang=request.LANGUAGE_CODE))))
+            x.institution.get_name(lang=request.LANGUAGE_CODE)))
     if settings_dict_get('CAT_AUTH', cat_instance) is None:
         cat_exists = False
         cat_api_direct = None
@@ -2452,7 +2452,7 @@ def adminlist(request):
         u.registrationprofile.activation_key == "ALREADY_ACTIVATED"
         for m in u.email.split(';')
     ]
-    data.sort(key=lambda d: six.text_type(d[0]))
+    data.sort(key=lambda d: d[0])
     resp_body = ""
     for (foreas, onoma, email) in data:
         resp_body += u'{email}\t{onoma}'.format(

--- a/utils/locale.py
+++ b/utils/locale.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*- vim:encoding=utf-8:
 # vim: tabstop=4:shiftwidth=4:softtabstop=4:expandtab
-# http://stackoverflow.com/a/24070673
 import locale
 import threading
 from contextlib import contextmanager
+from django.utils import six
+
+# http://stackoverflow.com/a/24070673
 
 LOCALE_LOCK = threading.Lock()
 
@@ -17,3 +19,8 @@ def setlocale(l, l_cat=locale.LC_ALL):
             yield
         finally:
             locale.setlocale(l_cat, saved)
+
+def compat_strxfrm(unicode_string):
+    if not six.PY3:
+        unicode_string = unicode_string.encode('utf-8')
+    return locale.strxfrm(unicode_string)


### PR DESCRIPTION
* Deduplicate and fix inconsistent `get_name()` methods
* Remove superfluous assignments to `obj.__str__`
* Remove now redundant `str()` (`unicode()`) wraps
* Replace method `get_str_func()` with nested function `compat_strxfrm()`
* Use `setlocale()` context manager and avoid hardcoding Greek sorting in `contacts` mgmt cmd
* Do not hardcode Greek sorting also in `adminlist` view
* Also use `compat_strxfrm()` in views