### PR TITLE
Fix font-awesome tags

### DIFF
--- a/djnro/static/js/showpass.js
+++ b/djnro/static/js/showpass.js
@@ -19,7 +19,7 @@ showPassword: function() {
 
 var input_password	= $(this);
 //create the icon and assign
-var icon_password = $('<span tabindex="100" class="add-on"><i class="icon-eye-open"></i></span>').css('cursor', 'help').tooltip({trigger:'click'});
+var icon_password = $('<span tabindex="100" class="add-on"><i class="fa fa-eye"></i></span>').css('cursor', 'help').tooltip({trigger:'click'});
 icon_password.attr('data-original-title', $(this).attr('value'));
 input_password.on({
 input	: function() {

--- a/djnro/templates/edumanage/institution_edit.html
+++ b/djnro/templates/edumanage/institution_edit.html
@@ -60,7 +60,7 @@
 				<label class="control-label" for="id_contact"><b>{% trans "Contacts" %}</b></label>
 				<div class="controls">
 					<div class="">{{ form.contact }}</div>
-					<button class="btn btn-small btn-info" id="add_contact"><i class="icon-plus-sign icon-white"></i>Add...</button>
+					<button class="btn btn-small btn-info" id="add_contact"><i class="fa fa-plus-circle" aria-hidden="true"></i>Add...</button>
 					  {% if form.contact.errors %} <div class="alert-danger"> {{ form.contact.errors|join_with_linebreaks }} </div>
                                        {% endif %} <span class="help-block"> {{ form.contact.help_text }}</span>
 
@@ -208,13 +208,13 @@ $(document).ready(function() {
         added: addButton,
     });
 
-     $(".delete-row").prepend('<i class="icon-remove-sign icon-white"></i> ').addClass('btn btn-small btn-warning');
-     $(".add-row").prepend('<i class="icon-plus-sign icon-white"></i> ').addClass('btn btn-small btn-info');
+     $(".delete-row").prepend('<i class="fa fa-times-circle" aria-hidden="true"></i> ').addClass('btn btn-small btn-warning');
+     $(".add-row").prepend('<i class="fa fa-plus-circle" aria-hidden="true"></i> ').addClass('btn btn-small btn-info');
 
 
 });
 function addButton(row){
-            $(row).find(".delete-row").prepend('<i class="icon-remove-sign icon-white"></i> ').addClass('btn btn-small btn-warning');
+            $(row).find(".delete-row").prepend('<i class="fa fa-times-circle" aria-hidden="true"></i> ').addClass('btn btn-small btn-warning');
         }
 
 </script>

--- a/djnro/templates/edumanage/services_edit.html
+++ b/djnro/templates/edumanage/services_edit.html
@@ -135,7 +135,7 @@
 		<div class="form-group {% if form.contact.errors %} error {% endif %}">
 			<label for="id_contact">{% trans "Contacts" %}</label>
 			<div class="controls">
-				{{ form.contact }} <button class="btn btn-small btn-info" id="add_contact"><i class="icon-plus-sign icon-white"></i>Add...</button>
+				{{ form.contact }} <button class="btn btn-small btn-info" id="add_contact"><i class="fa fa-plus-circle" aria-hidden="true"></i> Add...</button>
 				{% if form.contact.errors %} <div class="alert-danger"> {{ form.contact.errors|join_with_linebreaks }} </div>
 				{% endif %} <span class="help-block"> {{ form.contact.help_text }}</span>
 			</div>
@@ -584,8 +584,8 @@
 		            added: addButton
 		        });
 
-			 $(".delete-row").prepend('<i class="icon-remove-sign icon-white"></i> ').addClass('btn btn-small btn-warning');
-			 $(".add-row").prepend('<i class="icon-plus-sign icon-white"></i> ').addClass('btn btn-small btn-info');
+			 $(".delete-row").prepend('<i class="fa fa-times-circle" aria-hidden="true"></i> ').addClass('btn btn-small btn-warning');
+			 $(".add-row").prepend('<i class="fa fa-plus-circle" aria-hidden="true"></i> ').addClass('btn btn-small btn-info');
 
 			 $("#adduserSubmit").click(function(){
 					$.ajax({
@@ -628,7 +628,7 @@
 
 		});
 		function addButton(row){
-			$(row).find(".delete-row").prepend('<i class="icon-remove-sign icon-white"></i> ').addClass('btn btn-small btn-warning');
+			$(row).find(".delete-row").prepend('<i class="fa fa-times-circle" aria-hidden="true"></i> ').addClass('btn btn-small btn-warning');
 		}
 
 


### PR DESCRIPTION
When font-awesome was upgraded in #61, some icons got left behind. While mostly cosmetic, this did create a functional problem with the "show password" link.

This replaces all of the legacy v3.2 `icon-` tags with their direct equivalents in font-awesome 4.7.0. While I was at it, I've also been through the code and found all the `fa-` tags and verified they still exist in 4.7.0.

Given that all font-awesome icons are now tagged with the `fa` class, this should make a future upgrade a bit simpler too.