### PR TITLE
edumanage.admin: Formsets and validation for Name, Address, URL inlines

### DIFF
--- a/edumanage/admin.py
+++ b/edumanage/admin.py
@@ -18,26 +18,75 @@ from edumanage.models import (
     RealmData,
     CatEnrollment
 )
-from edumanage.forms import ServiceLocForm
+from edumanage.forms import (
+    ServiceLocForm,
+    ServiceLocURL_i18nForm,
+    RealmName_i18nFormSet,
+    InstitutionName_i18nFormSet,
+    ServiceLocName_i18nFormSet,
+    RealmAddress_i18nFormSet,
+    InstitutionAddress_i18nFormSet,
+    ServiceLocAddress_i18nFormSet,
+    RealmURL_i18nFormSet,
+    InstitutionURL_i18nFormSet,
+)
 
 from django.contrib.contenttypes import admin as contenttype_admin
 
 
-class NameInline(contenttype_admin.GenericTabularInline):
+class GenericTabularInlineValidateMin(contenttype_admin.GenericTabularInline):
+    def get_formset(self, *args, **kwargs): # pylint: disable=arguments-differ
+        if hasattr(self, 'validate_min'):
+            kwargs['validate_min'] = self.validate_min # pylint: disable=no-member
+        return super(GenericTabularInlineValidateMin, self).get_formset(
+            *args, **kwargs)
+
+class NameInline(GenericTabularInlineValidateMin):
     model = Name_i18n
 
+class RealmNameInline(NameInline):
+    formset = RealmName_i18nFormSet
+    min_num = 1
+    validate_min = True
 
-class UrlInline(contenttype_admin.GenericTabularInline):
+class InstitutionNameInline(RealmNameInline):
+    formset = InstitutionName_i18nFormSet
+
+class ServiceLocNameInline(NameInline):
+    formset = ServiceLocName_i18nFormSet
+
+class UrlInline(GenericTabularInlineValidateMin):
     model = URL_i18n
 
+class RealmUrlInline(UrlInline):
+    formset = RealmURL_i18nFormSet
+    min_num = 2
+    validate_min = True
 
-class AddressInline(contenttype_admin.GenericTabularInline):
+class InstitutionDetailsUrlInline(RealmUrlInline):
+    formset = InstitutionURL_i18nFormSet
+
+class ServiceLocUrlInline(UrlInline):
+    form = ServiceLocURL_i18nForm
+
+class AddressInline(GenericTabularInlineValidateMin):
     model = Address_i18n
+
+class RealmAddressInline(AddressInline):
+    formset = RealmAddress_i18nFormSet
+    min_num = 1
+    validate_min = True
+
+class InstitutionDetailsAddressInline(RealmAddressInline):
+    formset = InstitutionAddress_i18nFormSet
+
+class ServiceLocAddressInline(AddressInline):
+    formset = ServiceLocAddress_i18nFormSet
 
 
 class InstitutionAdmin(admin.ModelAdmin):
     inlines = [
-        NameInline,
+        InstitutionNameInline,
     ]
     list_filter = ('ertype',)
     readonly_fields = ('instid',)
@@ -45,7 +94,7 @@ class InstitutionAdmin(admin.ModelAdmin):
 
 class InstitutionDetailsAdmin(admin.ModelAdmin):
     inlines = [
-        AddressInline, UrlInline,
+        InstitutionDetailsAddressInline, InstitutionDetailsUrlInline,
     ]
     list_filter = ('institution__ertype',)
 
@@ -53,7 +102,7 @@ class InstitutionDetailsAdmin(admin.ModelAdmin):
 class ServiceLocAdmin(admin.ModelAdmin):
     list_display = ('get_name', 'institutionid')
     inlines = [
-        UrlInline, NameInline, AddressInline,
+        ServiceLocUrlInline, ServiceLocNameInline, ServiceLocAddressInline,
     ]
     list_filter = ('SSID', 'enc_level', 'tag')
     form = ServiceLocForm
@@ -62,7 +111,7 @@ class ServiceLocAdmin(admin.ModelAdmin):
 
 class RealmInLine(admin.ModelAdmin):
     inlines = [
-        UrlInline, NameInline
+        RealmUrlInline, RealmNameInline, RealmAddressInline,
     ]
 
 

--- a/edumanage/forms.py
+++ b/edumanage/forms.py
@@ -59,7 +59,8 @@ class URL_i18nForm(forms.ModelForm):
         fields = '__all__'
 
     def __init__(self, *args, **kwargs):
-        valid_urltypes = kwargs.pop('valid_urltypes', [])
+        valid_urltypes = getattr(self, 'valid_urltypes',
+                                 kwargs.pop('valid_urltypes', []))
         super(URL_i18nForm, self).__init__(*args, **kwargs)
         if not valid_urltypes:
             return
@@ -72,6 +73,9 @@ class URL_i18nForm(forms.ModelForm):
         new_choices = tuple(choice for choice in choices
                             if not choice[0] or choice[0] in valid_urltypes)
         urltype_field.choices = urltype_field.widget.choices = new_choices
+
+class ServiceLocURL_i18nForm(URL_i18nForm):
+    valid_urltypes = 'info'
 
 
 class MonLocalAuthnParamForm(forms.ModelForm):
@@ -296,6 +300,26 @@ class i18nFormSetDefaultLang(i18nFormSet): # pylint: disable=invalid-name
     )
 
 
+class RealmName_i18nFormSet(i18nFormSetDefaultLang): # pylint: disable=invalid-name
+    obj_descr = _('realm name')
+
+class InstitutionName_i18nFormSet(i18nFormSetDefaultLang): # pylint: disable=invalid-name
+    obj_descr = _('institution name')
+
+class ServiceLocName_i18nFormSet(i18nFormSetDefaultLang): # pylint: disable=invalid-name
+    obj_descr = _('location name')
+
+
+class RealmAddress_i18nFormSet(i18nFormSetDefaultLang): # pylint: disable=invalid-name
+    obj_descr = _('realm address')
+
+class InstitutionAddress_i18nFormSet(i18nFormSetDefaultLang): # pylint: disable=invalid-name
+    obj_descr = _('institution address')
+
+class ServiceLocAddress_i18nFormSet(i18nFormSetDefaultLang): # pylint: disable=invalid-name
+    obj_descr = _('location address')
+
+
 class URL_i18nFormSet(i18nFormSet): # pylint: disable=invalid-name
     required_value_sets = tuple(
         (
@@ -306,3 +330,10 @@ class URL_i18nFormSet(i18nFormSet): # pylint: disable=invalid-name
              urltype),
         ) for urltype in URL_i18n.URLTYPES
     )
+
+
+class RealmURL_i18nFormSet(URL_i18nFormSet): # pylint: disable=invalid-name
+    obj_descr = _('realm URL')
+
+class InstitutionURL_i18nFormSet(URL_i18nFormSet): # pylint: disable=invalid-name
+    obj_descr = _('institution URL')

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -62,12 +62,14 @@ from edumanage.forms import (
     InstRealmForm,
     UserProfileForm,
     ContactForm,
-    URL_i18nForm,
     MonLocalAuthnParamForm,
     InstRealmMonForm,
     ServiceLocForm,
-    i18nFormSetDefaultLang,
-    URL_i18nFormSet,
+    ServiceLocURL_i18nForm,
+    ServiceLocName_i18nFormSet,
+    InstitutionAddress_i18nFormSet,
+    ServiceLocAddress_i18nFormSet,
+    InstitutionURL_i18nFormSet,
     InstServerForm
 )
 from registration.models import RegistrationProfile
@@ -80,7 +82,6 @@ from django.utils.cache import (
 from django_dont_vary_on.decorators import dont_vary_on
 from utils.cat_helper import CatQuery
 from utils.locale import setlocale, compat_strxfrm
-from utils.functional import partialclass
 
 
 # Almost verbatim copy of django.views.i18n.set_language; however:
@@ -224,14 +225,12 @@ def add_institution_details(request, institution_pk):
 
     formset_params = (
         ('url', URL_i18n, {
-            'formset': partialclass(URL_i18nFormSet,
-                                    obj_descr=_('institution URL')),
+            'formset': InstitutionURL_i18nFormSet,
             'min_num': 2,
             'validate_min': True,
         }),
         ('addr', Address_i18n, {
-            'formset': partialclass(i18nFormSetDefaultLang,
-                                    obj_descr=_('institution address')),
+            'formset': InstitutionAddress_i18nFormSet,
             'min_num': 1,
             'validate_min': True,
         }),
@@ -399,17 +398,14 @@ def add_services(request, service_pk):
         )
     formset_params = (
         ('url', URL_i18n, {
-            'form': partialclass(URL_i18nForm,
-                                 valid_urltypes='info'),
+            'form': ServiceLocURL_i18nForm,
         }),
         ('name', Name_i18n, {
-            'formset': partialclass(i18nFormSetDefaultLang,
-                                    obj_descr=_('location name')),
+            'formset': ServiceLocName_i18nFormSet,
             'extra': 1,
         }),
         ('addr', Address_i18n, {
-            'formset': partialclass(i18nFormSetDefaultLang,
-                                    obj_descr=_('institution address')),
+            'formset': ServiceLocAddress_i18nFormSet,
             'min_num': 1,
             'validate_min': True,
         }),


### PR DESCRIPTION
Fix #77

* edumanage.forms: Subclass URL_i18nForm, i18nFormSetDefaultLang,
  URL_i18nFormSet with valid_urltypes, obj_descr class attributes for
  every use case
* edumanage.views: Replace partialclass() with above use-case specific
  form/formset classes
* edumanage.admin:
  * Override django.contrib.contenttypes.GenericTabularInline.get_formset()
    so as to have validate_min passed to generic_inlineformset_factory()
  * Reorganize inline classes and extend with form, formset, min_num,
    validate_min, so as to perform formset validation as appropriate
  * Add missing address inline to Realm