### PR TITLE
Limit participants display to active participants

### DIFF
--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -54,6 +54,7 @@ from edumanage.models import (
     Coordinates,
     ERTYPES,
     ERTYPE_ROLES,
+    PRODUCTION_STATES,
 )
 from .models import get_ertype_string
 from accounts.models import UserProfile
@@ -1669,7 +1670,8 @@ def api(request):
 
 @never_cache
 def participants(request):
-    institutions = Institution.objects.filter(institutiondetails__isnull=False).\
+    institutions = Institution.objects.filter(stage=PRODUCTION_STATES.ACTIVE,
+                                              institutiondetails__isnull=False).\
       select_related('institutiondetails')
     cat_instance = 'production'
     dets = []


### PR DESCRIPTION
The new data model includes a production state/stage of "preproduction/test". It probably doesn't make sense to include these in the public list of participants, and to limit the public view only to institutions that are marked as production-ready.

This change filters the /participants view accordingly.