### PR TITLE
Fix: Closest point API: ignore individual point parsing errors

### DIFF
--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1867,8 +1867,14 @@ def closest(request):
             pointlat = i['lat']
             pointtext = i['text']
             plainname = i['name']
-            dLat = rad(float(pointlat) - float(lat))
-            dLong = rad(float(pointlng) - float(lng))
+
+            try:
+                dLat = rad(float(pointlat) - float(lat))
+                dLong = rad(float(pointlng) - float(lng))
+
+            except ValueError:
+                continue # shrug: parsing error
+
             a = math.sin(dLat / 2) * math.sin(dLat / 2) + math.cos(rad(lat)) *\
                 math.cos(rad(float(pointlat))) * math.sin(dLong / 2) *\
                 math.sin(dLong / 2)


### PR DESCRIPTION
Hi @zmousm ,

I hope you are doing well.

Last week, we ran into issues where the upstream KML file had unparsable data in latitude/longitude fields (coordinates accidentally expressed as `'lat': "57°0'56.", 'lng': "9°58'36."` - with unicode degree character!

DjNRO started emailing us stack-trace error messages for each hit to the closest point API - and users were getting 500 Internal Server error.

This PR is a work-around that catches `ValueError` within the loop, just skipping invalid entries.

I raised the issue with the eduroam OT - they were not able to find where that error came from, and it disappeared in the meantime.  I still have a copy of the invalid data ... but while it's not possible to track how it got into the KML file, it seems to be reasonable to have a safeguard against future invalid data.

Does this look OK to you to merge?

Cheers,
Vlad