### PR TITLE
Streamline use of edumanage.views.base_response

### DIFF
--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -138,11 +138,6 @@ def manage_login_front(request):
             request,
             'edumanage/welcome_manage.html'
         )
-        # return render(
-        #     request,
-        #     'edumanage/welcome_manage.html',
-        #     context=base_response(request)
-        # )
     except AttributeError:
         return render(
             request,
@@ -174,11 +169,6 @@ def manage(request):
             request,
             'edumanage/welcome.html'
         )
-        # return render(
-        #     request,
-        #     'edumanage/welcome.html',
-        #     context=base_response(request)
-        # )
     services = ServiceLoc.objects.filter(institutionid=inst)
     services_list.extend([s for s in services])
     servers = InstServer.objects.filter(instid=inst)
@@ -191,15 +181,6 @@ def manage(request):
             'servers': servers_list,
         }
     )
-    # return render(
-    #     request,
-    #     'edumanage/welcome.html',
-    #     context=merge_dicts({
-    #         'institution': inst,
-    #         'services': services_list,
-    #         'servers': servers_list,
-    #     }, base_response(request))
-    # )
 
 
 @login_required
@@ -216,13 +197,6 @@ def institutions(request):
         request,
         'edumanage/institution.html'
     )
-    # return render(
-    #     request,
-    #     'edumanage/institution.html',
-    #     context=merge_dicts({
-    #         'institution': inst,
-    #     }, base_response(request))
-    # )
 
 
 @login_required
@@ -297,16 +271,6 @@ def add_institution_details(request, institution_pk):
                 'addrs_form': formsets['addr']
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/institution_edit.html',
-        #     context=merge_dicts({
-        #         'institution': inst,
-        #         'form': form,
-        #         'urls_form': formsets['url'],
-        #         'addrs_form': formsets['addr']
-        #     }, base_response(request))
-        # )
     if request.method == 'POST':
         request_data = request.POST.copy()
         form = InstDetailsForm(request_data, **form_kwargs)
@@ -337,16 +301,6 @@ def add_institution_details(request, institution_pk):
                 'addrs_form': formsets['addr']
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/institution_edit.html',
-        #     context=merge_dicts({
-        #         'institution': inst,
-        #         'form': form,
-        #         'urls_form': formsets['url'],
-        #         'addrs_form': formsets['addr']
-        #     }, base_response(request))
-        # )
 
 
 @login_required
@@ -373,11 +327,6 @@ def services(request, service_pk):
             request,
             'edumanage/services.html'
         )
-        # return render(
-        #     request,
-        #     'edumanage/services.html',
-        #     context=merge_dicts({'institution': inst}, base_response(request))
-        # )
     try:
         services = ServiceLoc.objects.filter(institutionid=inst)
     except ServiceLoc.DoesNotExist:
@@ -400,14 +349,6 @@ def services(request, service_pk):
                 'service': services,
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/service_details.html',
-        #     context=merge_dicts({
-        #         'institution': inst,
-        #         'service': services,
-        #     }, base_response(request))
-        # )
 
     return render_with_base_ctx(
         request,
@@ -416,14 +357,6 @@ def services(request, service_pk):
             'services': services,
         }
     )
-    # return render(
-    #     request,
-    #     'edumanage/services.html',
-    #     context=merge_dicts({
-    #         'institution': inst,
-    #         'services': services,
-    #     }, base_response(request))
-    # )
 
 
 @login_required
@@ -453,11 +386,6 @@ def add_services(request, service_pk):
             'edumanage/services_edit.html',
             context={'edit': edit}
         )
-        # return render(
-        #     request,
-        #     'edumanage/services_edit.html',
-        #     context=merge_dicts({'edit': edit}, base_response(request))
-        # )
     formset_params = (
         ('url', URL_i18n, {
             'form': ServiceLocURL_i18nForm,
@@ -521,17 +449,6 @@ def add_services(request, service_pk):
                 "edit": edit
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/services_edit.html',
-        #     context=merge_dicts({
-        #         'form': form,
-        #         'services_form': formsets['name'],
-        #         'urls_form': formsets['url'],
-        #         'addrs_form': formsets['addr'],
-        #         "edit": edit
-        #     }, base_response(request))
-        # )
     if request.method == 'POST':
         request_data = request.POST.copy()
         form = ServiceLocForm(request_data, **form_kwargs)
@@ -567,18 +484,6 @@ def add_services(request, service_pk):
                 'edit': edit
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/services_edit.html',
-        #     context=merge_dicts({
-        #         'institution': inst,
-        #         'form': form,
-        #         'services_form': formsets['name'],
-        #         'urls_form': formsets['url'],
-        #         'addrs_form': formsets['addr'],
-        #         'edit': edit
-        #     }, base_response(request))
-        # )
 
 
 @login_required
@@ -636,14 +541,6 @@ def servers(request, server_pk):
                 'server': servers,
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/server_details.html',
-        #     context=merge_dicts({
-        #         'institution': inst,
-        #         'server': servers,
-        #     }, base_response(request))
-        # )
     return render_with_base_ctx(
         request,
         'edumanage/servers.html',
@@ -651,13 +548,6 @@ def servers(request, server_pk):
             'servers': servers
         }
     )
-    # return render(
-    #     request,
-    #     'edumanage/servers.html',
-    #     context=merge_dicts({
-    #         'servers': servers
-    #     }, base_response(request))
-    # )
 
 
 @login_required
@@ -701,14 +591,6 @@ def add_server(request, server_pk):
                 'edit': edit
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/servers_edit.html',
-        #     context=merge_dicts({
-        #         'form': form,
-        #         'edit': edit
-        #     }, base_response(request))
-        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -741,15 +623,6 @@ def add_server(request, server_pk):
                 'edit': edit
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/servers_edit.html',
-        #     context=merge_dicts({
-        #         'institution': inst,
-        #         'form': form,
-        #         'edit': edit
-        #     }, base_response(request))
-        # )
 
 
 @login_required
@@ -779,11 +652,6 @@ def cat_enroll(request):
             'edumanage/catenroll.html',
             context={'status': False}
         )
-        # return render(
-        #     request,
-        #     'edumanage/catenroll.html',
-        #     context=merge_dicts({'status': False}, base_response(request))
-        # )
     if request.method == "GET":
         current_enrollments = inst.catenrollment_set.all()
         current_enrollments_list = current_enrollments.values_list(
@@ -804,11 +672,6 @@ def cat_enroll(request):
                 'edumanage/catenroll.html',
                 context={'status': False}
             )
-            # return render(
-            #     request,
-            #     'edumanage/catenroll.html',
-            #     context=merge_dicts({'status': False}, base_response(request))
-            # )
         return render_with_base_ctx(
             request,
             'edumanage/catenroll.html',
@@ -818,15 +681,6 @@ def cat_enroll(request):
                 'cat_instances': available_enrollments
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/catenroll.html',
-        #     context=merge_dicts({
-        #         'status': True,
-        #         'current_enrollments': current_enrollments,
-        #         'cat_instances': available_enrollments
-        #     }, base_response(request))
-        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         instance = request_data['catinstance']
@@ -896,17 +750,6 @@ def cat_enroll(request):
                 'inst_uid': inst_uid
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/catenroll.html',
-        #     context=merge_dicts({
-        #         'status': True,
-        #         'response_status': status,
-        #         'response': response,
-        #         'cat_url': cat_url,
-        #         'inst_uid': inst_uid
-        #     }, base_response(request))
-        # )
 
 
 @login_required
@@ -961,11 +804,6 @@ def realms(request):
         'edumanage/realms.html',
         context={'realms': realms}
     )
-    # return render(
-    #     request,
-    #     'edumanage/realms.html',
-    #     context=merge_dicts({'realms': realms}, base_response(request))
-    # )
 
 
 @login_required
@@ -991,11 +829,6 @@ def add_realm(request, realm_pk):
             'edumanage/realms_edit.html',
             context={'edit': edit}
         )
-        # return render(
-        #     request,
-        #     'edumanage/realms_edit.html',
-        #     context=merge_dicts({'edit': edit}, base_response(request))
-        # )
     if request.method == "GET":
 
         # Determine add or edit
@@ -1027,11 +860,6 @@ def add_realm(request, realm_pk):
             'edumanage/realms_edit.html',
             context={'form': form, 'edit': edit}
         )
-        # return render(
-        #     request,
-        #     'edumanage/realms_edit.html',
-        #     context=merge_dicts({'form': form, 'edit': edit}, base_response(request))
-        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -1066,11 +894,6 @@ def add_realm(request, realm_pk):
             'edumanage/realms_edit.html',
             context={'form': form, 'edit': edit}
         )
-        # return render(
-        #     request,
-        #     'edumanage/realms_edit.html',
-        #     context=merge_dicts({'institution': inst, 'form': form, 'edit': edit}, base_response(request))
-        # )
 
 
 @login_required
@@ -1129,11 +952,6 @@ def contacts(request):
         'edumanage/contacts.html',
         context={'contacts': contacts}
     )
-    # return render(
-    #     request,
-    #     'edumanage/contacts.html',
-    #     context=merge_dicts({'contacts': contacts}, base_response(request))
-    # )
 
 
 @login_required
@@ -1181,14 +999,6 @@ def add_contact(request, contact_pk):
                 'edit': edit
             }
         )
-        # return render(
-        #     request,
-        #     'edumanage/contacts_edit.html',
-        #     context=merge_dicts({
-        #         'form': form,
-        #         'edit': edit
-        #     }, base_response(request))
-        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -1223,11 +1033,6 @@ def add_contact(request, contact_pk):
             'edumanage/contacts_edit.html',
             context={'form': form, "edit": edit}
         )
-        # return render(
-        #     request,
-        #     'edumanage/contacts_edit.html',
-        #     context=merge_dicts({'form': form, "edit": edit}, base_response(request))
-        # )
 
 
 @login_required
@@ -1307,11 +1112,6 @@ def instrealmmon(request):
         'edumanage/instrealmmons.html',
         context={'realms': instrealmmons}
     )
-    # return render(
-    #     request,
-    #     'edumanage/instrealmmons.html',
-    #     context=merge_dicts({'realms': instrealmmons}, base_response(request))
-    # )
 
 
 @login_required
@@ -1360,11 +1160,6 @@ def add_instrealmmon(request, instrealmmon_pk):
             'edumanage/instrealmmon_edit.html',
             context={'form': form, 'edit': edit}
         )
-        # return render(
-        #     request,
-        #     'edumanage/instrealmmon_edit.html',
-        #     context=merge_dicts({'form': form, 'edit': edit}, base_response(request))
-        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -1398,11 +1193,6 @@ def add_instrealmmon(request, instrealmmon_pk):
             'edumanage/instrealmmon_edit.html',
             context={'form': form, "edit": edit}
         )
-        # return render(
-        #     request,
-        #     'edumanage/instrealmmon_edit.html',
-        #     context=merge_dicts({'form': form, "edit": edit}, base_response(request))
-        # )
 
 
 @login_required
@@ -1489,11 +1279,6 @@ def add_monlocauthpar(request, instrealmmon_pk, monlocauthpar_pk):
             'edumanage/monlocauthpar_edit.html',
             context={'form': form,"edit" : edit, "realm":instrealmmon}
         )
-        # return render(
-        #     request,
-        #     'edumanage/monlocauthpar_edit.html',
-        #     context=merge_dicts({'form': form,"edit" : edit, "realm":instrealmmon}, base_response(request))
-        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -1537,11 +1322,6 @@ def add_monlocauthpar(request, instrealmmon_pk, monlocauthpar_pk):
             'edumanage/monlocauthpar_edit.html',
             context={'form': form, "edit": edit, "realm":instrealmmon}
         )
-        # return render(
-        #     request,
-        #     'edumanage/monlocauthpar_edit.html',
-        #     context=merge_dicts({'form': form, "edit": edit, "realm":instrealmmon}, base_response(request))
-        # )
 
 
 @login_required
@@ -1590,11 +1370,6 @@ def adduser(request):
             'edumanage/add_user.html',
             context={'form': form}
         )
-        # return render(
-        #     request,
-        #     'edumanage/add_user.html',
-        #     context=merge_dicts({'form': form}, base_response(request))
-        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         form = ContactForm(request_data)
@@ -1618,11 +1393,6 @@ def adduser(request):
                 'edumanage/add_user.html',
                 context={'form': form}
             )
-            # return render(
-            #     request,
-            #     'edumanage/add_user.html',
-            #     context=merge_dicts({'form': form}, base_response(request))
-            # )
 
 
 def base_response(request):
@@ -3024,7 +2794,3 @@ def settings_dict_get(setting, *keys, **opts):
     if dct == {}:
         dct = opts.get('default', None)
     return dct
-
-# utility function to merge two dictionaries
-def merge_dicts(dict1, dict2):
-    return dict(itertools.chain(dict1.items(), dict2.items()))

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -134,11 +134,15 @@ def manage_login_front(request):
     try:
         profile = user.userprofile
     except UserProfile.DoesNotExist:
-        return render(
+        return render_with_base_ctx(
             request,
-            'edumanage/welcome_manage.html',
-            context=base_response(request)
+            'edumanage/welcome_manage.html'
         )
+        # return render(
+        #     request,
+        #     'edumanage/welcome_manage.html',
+        #     context=base_response(request)
+        # )
     except AttributeError:
         return render(
             request,
@@ -166,24 +170,36 @@ def manage(request):
         profile = user.userprofile
         inst = profile.institution
     except UserProfile.DoesNotExist:
-        return render(
+        return render_with_base_ctx(
             request,
-            'edumanage/welcome.html',
-            context=base_response(request)
+            'edumanage/welcome.html'
         )
+        # return render(
+        #     request,
+        #     'edumanage/welcome.html',
+        #     context=base_response(request)
+        # )
     services = ServiceLoc.objects.filter(institutionid=inst)
     services_list.extend([s for s in services])
     servers = InstServer.objects.filter(instid=inst)
     servers_list.extend([s for s in servers])
-    return render(
+    return render_with_base_ctx(
         request,
         'edumanage/welcome.html',
-        context=merge_dicts({
-            'institution': inst,
+        context={
             'services': services_list,
             'servers': servers_list,
-        }, base_response(request))
+        }
     )
+    # return render(
+    #     request,
+    #     'edumanage/welcome.html',
+    #     context=merge_dicts({
+    #         'institution': inst,
+    #         'services': services_list,
+    #         'servers': servers_list,
+    #     }, base_response(request))
+    # )
 
 
 @login_required
@@ -196,13 +212,17 @@ def institutions(request):
         inst = profile.institution
     except UserProfile.DoesNotExist:
         return HttpResponseRedirect(reverse("manage"))
-    return render(
+    return render_with_base_ctx(
         request,
-        'edumanage/institution.html',
-        context=merge_dicts({
-            'institution': inst,
-        }, base_response(request))
+        'edumanage/institution.html'
     )
+    # return render(
+    #     request,
+    #     'edumanage/institution.html',
+    #     context=merge_dicts({
+    #         'institution': inst,
+    #     }, base_response(request))
+    # )
 
 
 @login_required
@@ -268,16 +288,25 @@ def add_institution_details(request, institution_pk):
             formsets[form_key] = generic_inlineformset_factory(
                 model, **fsf_kwargs
             )(**fs_kwargs)
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/institution_edit.html',
-            context=merge_dicts({
-                'institution': inst,
+            context={
                 'form': form,
                 'urls_form': formsets['url'],
                 'addrs_form': formsets['addr']
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/institution_edit.html',
+        #     context=merge_dicts({
+        #         'institution': inst,
+        #         'form': form,
+        #         'urls_form': formsets['url'],
+        #         'addrs_form': formsets['addr']
+        #     }, base_response(request))
+        # )
     if request.method == 'POST':
         request_data = request.POST.copy()
         form = InstDetailsForm(request_data, **form_kwargs)
@@ -299,16 +328,25 @@ def add_institution_details(request, institution_pk):
             return HttpResponseRedirect(reverse("institutions"))
         # invalid form data, render page with errors
         form.fields.update(form_fields)
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/institution_edit.html',
-            context=merge_dicts({
-                'institution': inst,
+            context={
                 'form': form,
                 'urls_form': formsets['url'],
                 'addrs_form': formsets['addr']
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/institution_edit.html',
+        #     context=merge_dicts({
+        #         'institution': inst,
+        #         'form': form,
+        #         'urls_form': formsets['url'],
+        #         'addrs_form': formsets['addr']
+        #     }, base_response(request))
+        # )
 
 
 @login_required
@@ -331,11 +369,15 @@ def services(request, service_pk):
             messages.ERROR,
             'Cannot add/edit Location. Your institution should be either SP or IdP/SP'
         )
-        return render(
+        return render_with_base_ctx(
             request,
-            'edumanage/services.html',
-            context=merge_dicts({'institution': inst}, base_response(request))
+            'edumanage/services.html'
         )
+        # return render(
+        #     request,
+        #     'edumanage/services.html',
+        #     context=merge_dicts({'institution': inst}, base_response(request))
+        # )
     try:
         services = ServiceLoc.objects.filter(institutionid=inst)
     except ServiceLoc.DoesNotExist:
@@ -351,23 +393,37 @@ def services(request, service_pk):
                 'You have no rights to view this location'
             )
             return HttpResponseRedirect(reverse("services"))
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/service_details.html',
-            context=merge_dicts({
-                'institution': inst,
+            context={
                 'service': services,
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/service_details.html',
+        #     context=merge_dicts({
+        #         'institution': inst,
+        #         'service': services,
+        #     }, base_response(request))
+        # )
 
-    return render(
+    return render_with_base_ctx(
         request,
         'edumanage/services.html',
-        context=merge_dicts({
-            'institution': inst,
+        context={
             'services': services,
-        }, base_response(request))
+        }
     )
+    # return render(
+    #     request,
+    #     'edumanage/services.html',
+    #     context=merge_dicts({
+    #         'institution': inst,
+    #         'services': services,
+    #     }, base_response(request))
+    # )
 
 
 @login_required
@@ -392,11 +448,16 @@ def add_services(request, service_pk):
             messages.ERROR,
             'Cannot add/edit Service. Your institution should be either SP or IdP/SP'
         )
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/services_edit.html',
-            context=merge_dicts({'edit': edit}, base_response(request))
+            context={'edit': edit}
         )
+        # return render(
+        #     request,
+        #     'edumanage/services_edit.html',
+        #     context=merge_dicts({'edit': edit}, base_response(request))
+        # )
     formset_params = (
         ('url', URL_i18n, {
             'form': ServiceLocURL_i18nForm,
@@ -449,17 +510,28 @@ def add_services(request, service_pk):
                 model, **fsf_kwargs)(**fs_kwargs)
         if service:
             edit = True
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/services_edit.html',
-            context=merge_dicts({
+            context={
                 'form': form,
                 'services_form': formsets['name'],
                 'urls_form': formsets['url'],
                 'addrs_form': formsets['addr'],
                 "edit": edit
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/services_edit.html',
+        #     context=merge_dicts({
+        #         'form': form,
+        #         'services_form': formsets['name'],
+        #         'urls_form': formsets['url'],
+        #         'addrs_form': formsets['addr'],
+        #         "edit": edit
+        #     }, base_response(request))
+        # )
     if request.method == 'POST':
         request_data = request.POST.copy()
         form = ServiceLocForm(request_data, **form_kwargs)
@@ -484,18 +556,29 @@ def add_services(request, service_pk):
         form.fields.update(form_fields)
         if service:
             edit = True
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/services_edit.html',
-            context=merge_dicts({
-                'institution': inst,
+            context={
                 'form': form,
                 'services_form': formsets['name'],
                 'urls_form': formsets['url'],
                 'addrs_form': formsets['addr'],
                 'edit': edit
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/services_edit.html',
+        #     context=merge_dicts({
+        #         'institution': inst,
+        #         'form': form,
+        #         'services_form': formsets['name'],
+        #         'urls_form': formsets['url'],
+        #         'addrs_form': formsets['addr'],
+        #         'edit': edit
+        #     }, base_response(request))
+        # )
 
 
 @login_required
@@ -546,21 +629,35 @@ def servers(request, server_pk):
         servers = InstServer.objects.filter(instid=inst)
     if server_pk:
         servers = servers.get(pk=server_pk)
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/server_details.html',
-            context=merge_dicts({
-                'institution': inst,
+            context={
                 'server': servers,
-            }, base_response(request))
+            }
         )
-    return render(
+        # return render(
+        #     request,
+        #     'edumanage/server_details.html',
+        #     context=merge_dicts({
+        #         'institution': inst,
+        #         'server': servers,
+        #     }, base_response(request))
+        # )
+    return render_with_base_ctx(
         request,
         'edumanage/servers.html',
-        context=merge_dicts({
+        context={
             'servers': servers
-        }, base_response(request))
+        }
     )
+    # return render(
+    #     request,
+    #     'edumanage/servers.html',
+    #     context=merge_dicts({
+    #         'servers': servers
+    #     }, base_response(request))
+    # )
 
 
 @login_required
@@ -596,14 +693,22 @@ def add_server(request, server_pk):
         if server:
             edit = True
 
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/servers_edit.html',
-            context=merge_dicts({
+            context={
                 'form': form,
                 'edit': edit
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/servers_edit.html',
+        #     context=merge_dicts({
+        #         'form': form,
+        #         'edit': edit
+        #     }, base_response(request))
+        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -628,15 +733,23 @@ def add_server(request, server_pk):
             return HttpResponseRedirect(reverse("servers"))
         if server:
             edit = True
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/servers_edit.html',
-            context=merge_dicts({
-                'institution': inst,
+            context={
                 'form': form,
                 'edit': edit
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/servers_edit.html',
+        #     context=merge_dicts({
+        #         'institution': inst,
+        #         'form': form,
+        #         'edit': edit
+        #     }, base_response(request))
+        # )
 
 
 @login_required
@@ -661,11 +774,16 @@ def cat_enroll(request):
             messages.ERROR,
             'Cannot add/edit Enrollments. Your institution should be either IdP or IdP/SP'
         )
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/catenroll.html',
-            context=merge_dicts({'status': False}, base_response(request))
+            context={'status': False}
         )
+        # return render(
+        #     request,
+        #     'edumanage/catenroll.html',
+        #     context=merge_dicts({'status': False}, base_response(request))
+        # )
     if request.method == "GET":
         current_enrollments = inst.catenrollment_set.all()
         current_enrollments_list = current_enrollments.values_list(
@@ -681,20 +799,34 @@ def cat_enroll(request):
                 messages.ERROR,
                 'There are no available CAT instances for your institution enrollment'
             )
-            return render(
+            return render_with_base_ctx(
                 request,
                 'edumanage/catenroll.html',
-                context=merge_dicts({'status': False}, base_response(request))
+                context={'status': False}
             )
-        return render(
+            # return render(
+            #     request,
+            #     'edumanage/catenroll.html',
+            #     context=merge_dicts({'status': False}, base_response(request))
+            # )
+        return render_with_base_ctx(
             request,
             'edumanage/catenroll.html',
-            context=merge_dicts({
+            context={
                 'status': True,
                 'current_enrollments': current_enrollments,
                 'cat_instances': available_enrollments
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/catenroll.html',
+        #     context=merge_dicts({
+        #         'status': True,
+        #         'current_enrollments': current_enrollments,
+        #         'cat_instances': available_enrollments
+        #     }, base_response(request))
+        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         instance = request_data['catinstance']
@@ -753,17 +885,28 @@ def cat_enroll(request):
         else:
             status = enroll.status
             response = enroll.response
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/catenroll.html',
-            context=merge_dicts({
+            context={
                 'status': True,
                 'response_status': status,
                 'response': response,
                 'cat_url': cat_url,
                 'inst_uid': inst_uid
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/catenroll.html',
+        #     context=merge_dicts({
+        #         'status': True,
+        #         'response_status': status,
+        #         'response': response,
+        #         'cat_url': cat_url,
+        #         'inst_uid': inst_uid
+        #     }, base_response(request))
+        # )
 
 
 @login_required
@@ -813,11 +956,16 @@ def realms(request):
             messages.ERROR,
             'Cannot add/edit Realms. Your institution should be either IdP or IdP/SP'
         )
-    return render(
+    return render_with_base_ctx(
         request,
         'edumanage/realms.html',
-        context=merge_dicts({'realms': realms}, base_response(request))
+        context={'realms': realms}
     )
+    # return render(
+    #     request,
+    #     'edumanage/realms.html',
+    #     context=merge_dicts({'realms': realms}, base_response(request))
+    # )
 
 
 @login_required
@@ -838,11 +986,16 @@ def add_realm(request, realm_pk):
         return HttpResponseRedirect(reverse("manage"))
     if inst.ertype not in ERTYPE_ROLES.IDP:
         messages.add_message(request, messages.ERROR, 'Cannot add/edit Realm. Your institution should be either IdP or IdP/SP')
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/realms_edit.html',
-            context=merge_dicts({'edit': edit}, base_response(request))
+            context={'edit': edit}
         )
+        # return render(
+        #     request,
+        #     'edumanage/realms_edit.html',
+        #     context=merge_dicts({'edit': edit}, base_response(request))
+        # )
     if request.method == "GET":
 
         # Determine add or edit
@@ -869,11 +1022,16 @@ def add_realm(request, realm_pk):
         )
         if realm:
             edit = True
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/realms_edit.html',
-            context=merge_dicts({'form': form, 'edit': edit}, base_response(request))
+            context={'form': form, 'edit': edit}
         )
+        # return render(
+        #     request,
+        #     'edumanage/realms_edit.html',
+        #     context=merge_dicts({'form': form, 'edit': edit}, base_response(request))
+        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -903,11 +1061,16 @@ def add_realm(request, realm_pk):
             )
         if realm:
             edit = True
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/realms_edit.html',
-            context=merge_dicts({'institution': inst, 'form': form, 'edit': edit}, base_response(request))
+            context={'form': form, 'edit': edit}
         )
+        # return render(
+        #     request,
+        #     'edumanage/realms_edit.html',
+        #     context=merge_dicts({'institution': inst, 'form': form, 'edit': edit}, base_response(request))
+        # )
 
 
 @login_required
@@ -961,11 +1124,16 @@ def contacts(request):
             )
         ])
         contacts = Contact.objects.filter(pk__in=instcontacts)
-    return render(
+    return render_with_base_ctx(
         request,
         'edumanage/contacts.html',
-        context=merge_dicts({'contacts': contacts}, base_response(request))
+        context={'contacts': contacts}
     )
+    # return render(
+    #     request,
+    #     'edumanage/contacts.html',
+    #     context=merge_dicts({'contacts': contacts}, base_response(request))
+    # )
 
 
 @login_required
@@ -1005,14 +1173,22 @@ def add_contact(request, contact_pk):
                 return HttpResponseRedirect(reverse("contacts"))
         if contact:
             edit = True
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/contacts_edit.html',
-            context=merge_dicts({
+            context={
                 'form': form,
                 'edit': edit
-            }, base_response(request))
+            }
         )
+        # return render(
+        #     request,
+        #     'edumanage/contacts_edit.html',
+        #     context=merge_dicts({
+        #         'form': form,
+        #         'edit': edit
+        #     }, base_response(request))
+        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -1042,11 +1218,16 @@ def add_contact(request, contact_pk):
             return HttpResponseRedirect(reverse("contacts"))
         if contact:
             edit = True
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/contacts_edit.html',
-            context=merge_dicts({'form': form, "edit": edit}, base_response(request))
+            context={'form': form, "edit": edit}
         )
+        # return render(
+        #     request,
+        #     'edumanage/contacts_edit.html',
+        #     context=merge_dicts({'form': form, "edit": edit}, base_response(request))
+        # )
 
 
 @login_required
@@ -1121,11 +1302,16 @@ def instrealmmon(request):
         return HttpResponseRedirect(reverse("manage"))
     if inst:
         instrealmmons = InstRealmMon.objects.filter(realm__instid=inst)
-    return render(
+    return render_with_base_ctx(
         request,
         'edumanage/instrealmmons.html',
-        context=merge_dicts({'realms': instrealmmons}, base_response(request))
+        context={'realms': instrealmmons}
     )
+    # return render(
+    #     request,
+    #     'edumanage/instrealmmons.html',
+    #     context=merge_dicts({'realms': instrealmmons}, base_response(request))
+    # )
 
 
 @login_required
@@ -1169,11 +1355,16 @@ def add_instrealmmon(request, instrealmmon_pk):
             ),
             empty_label=None
         )
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/instrealmmon_edit.html',
-            context=merge_dicts({'form': form, 'edit': edit}, base_response(request))
+            context={'form': form, 'edit': edit}
         )
+        # return render(
+        #     request,
+        #     'edumanage/instrealmmon_edit.html',
+        #     context=merge_dicts({'form': form, 'edit': edit}, base_response(request))
+        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -1202,11 +1393,16 @@ def add_instrealmmon(request, instrealmmon_pk):
             ),
             empty_label=None
         )
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/instrealmmon_edit.html',
-            context=merge_dicts({'form': form, "edit": edit}, base_response(request))
+            context={'form': form, "edit": edit}
         )
+        # return render(
+        #     request,
+        #     'edumanage/instrealmmon_edit.html',
+        #     context=merge_dicts({'form': form, "edit": edit}, base_response(request))
+        # )
 
 
 @login_required
@@ -1288,11 +1484,16 @@ def add_monlocauthpar(request, instrealmmon_pk, monlocauthpar_pk):
             queryset=InstRealmMon.objects.filter(pk=instrealmmon.pk),
             empty_label=None
         )
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/monlocauthpar_edit.html',
-            context=merge_dicts({'form': form,"edit" : edit, "realm":instrealmmon}, base_response(request))
+            context={'form': form,"edit" : edit, "realm":instrealmmon}
         )
+        # return render(
+        #     request,
+        #     'edumanage/monlocauthpar_edit.html',
+        #     context=merge_dicts({'form': form,"edit" : edit, "realm":instrealmmon}, base_response(request))
+        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         try:
@@ -1331,11 +1532,16 @@ def add_monlocauthpar(request, instrealmmon_pk, monlocauthpar_pk):
             queryset=InstRealmMon.objects.filter(pk=instrealmmon.pk),
             empty_label=None
         )
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/monlocauthpar_edit.html',
-            context=merge_dicts({'form': form, "edit": edit, "realm":instrealmmon}, base_response(request))
+            context={'form': form, "edit": edit, "realm":instrealmmon}
         )
+        # return render(
+        #     request,
+        #     'edumanage/monlocauthpar_edit.html',
+        #     context=merge_dicts({'form': form, "edit": edit, "realm":instrealmmon}, base_response(request))
+        # )
 
 
 @login_required
@@ -1379,11 +1585,16 @@ def adduser(request):
 
     if request.method == "GET":
         form = ContactForm()
-        return render(
+        return render_with_base_ctx(
             request,
             'edumanage/add_user.html',
-            context=merge_dicts({'form': form}, base_response(request))
+            context={'form': form}
         )
+        # return render(
+        #     request,
+        #     'edumanage/add_user.html',
+        #     context=merge_dicts({'form': form}, base_response(request))
+        # )
     elif request.method == 'POST':
         request_data = request.POST.copy()
         form = ContactForm(request_data)
@@ -1402,15 +1613,18 @@ def adduser(request):
                 content_type='application/json'
             )
         else:
-            return render(
+            return render_with_base_ctx(
                 request,
                 'edumanage/add_user.html',
-                context=merge_dicts({'form': form}, base_response(request))
+                context={'form': form}
             )
+            # return render(
+            #     request,
+            #     'edumanage/add_user.html',
+            #     context=merge_dicts({'form': form}, base_response(request))
+            # )
 
 
-@login_required
-@social_active_required
 def base_response(request):
     user = request.user
     inst = []
@@ -1464,6 +1678,13 @@ def base_response(request):
         'ERTYPES': ERTYPES,
         'ERTYPE_ROLES': ERTYPE_ROLES,
     }
+
+
+def render_with_base_ctx(request, *args, **kwargs):
+    ctx = base_response(request)
+    ctx.update(kwargs.get("context", {}))
+    kwargs['context'] = ctx
+    return render(request, *args, **kwargs)
 
 
 @login_required


### PR DESCRIPTION
* Add `django.shortcuts.render()` wrapper which calls `base_response()`
* Passing context to the wrapper now overrides context from `base_response()`
* Remove decorators from `base_response()`
* Remove now unused function `merge_dicts()`