### PR TITLE
fix: mark CSRF cookies as secure

### DIFF
--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -246,8 +246,9 @@ KML_FILE = os.path.join(PROJECT_DIR, 'all.kml')
 
 EDUROAM_KML_URL = 'https://monitor.eduroam.org/kml/all.kml'
 
-# Request session cookies to be marked as secure
+# Request session and CSRF cookies to be marked as secure
 SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 TINYMCE_COMPRESSOR = True
 


### PR DESCRIPTION
Hi @zmousm ,

I spotted a Firefox warning issued for our DjNRO site:

```
Cookie “csrftoken” will be soon rejected because it has the “SameSite” attribute
set to “None” or an invalid value, without the “secure” attribute.
To know more about the “SameSite“ attribute, read
https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
```

And I saw that while ` djnro/settings.py` sets `SESSION_COOKIE_SECURE` to `True`, it wasn't setting `CSRF_COOKIE_SECURE` - so adding that in a trivial fix.

Should be easy to merge.

Cheers,
Vlad