### PR TITLE
Clickjacking protection

### DIFF
--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -118,9 +118,9 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
-    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     # Simple clickjacking protection:
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -119,8 +119,8 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    # Uncomment the next line for simple clickjacking protection:
-    # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # Simple clickjacking protection:
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
Hi @zmousm ,

I hope you are doing well.

I've just noticed (from output of a security scanner against our DjNRO instance) that DjNRO is not issuing the X-Frame-Options header - which has become standard expectation of web applications these days.

And I found the middleware that would take care of that has been in the project `settings.py` file the whole time, just commented out.

This PR just uncomments it - and does a slight reorder to extend the protection also to flag pages.

Successfully tested in our TEST environment - reports a clean pass from the scanner, and no functionality broke.

Does that look OK to you to merge?

Cheers,
Vlad
