### PR TITLE
fix: edumanage/views/cat_user_api_proxy: 2to3 fix for CT handling

### DIFF
--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -2685,7 +2685,7 @@ def cat_user_api_proxy(request, cat_instance):
     except (KeyError, ValueError):
         cl = len(r.content)
     cd = r.headers.get('content-disposition', None)
-    if ct.startswith('text/html') and cl > 0 and r.content[0] in ['{', '[']:
+    if ct.startswith('text/html') and cl > 0 and r.content[0:1] in [b'{', b'[']:
         ct = ct.replace('text/html', 'application/json')
     resp = HttpResponse(r.content, content_type=ct)
     resp.status_code = r.status_code

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -2685,7 +2685,7 @@ def cat_user_api_proxy(request, cat_instance):
     except (KeyError, ValueError):
         cl = len(r.content)
     cd = r.headers.get('content-disposition', None)
-    if ct.startswith('text/html') and cl > 0 and r.content[0:1] in [b'{', b'[']:
+    if ct.startswith('text/html') and cl > 0 and r.text[0] in ['{', '[']:
         ct = ct.replace('text/html', 'application/json')
     resp = HttpResponse(r.content, content_type=ct)
     resp.status_code = r.status_code


### PR DESCRIPTION
The code in cat_user_api_proxy changes Content-Type from `text/html` to `application/json` if it detects the payload returned is JSON - starts with `'['` or `'{'`.

However, this code was missed in the Python3 overhaul.

In Python Requests, the type of response.content is bytes.

The existing comparison: `r.content[0] in ['{', '[']` works in Python2, where strings and bytes are not distinguished.

However, in Python3, `r.content[0]` returns just the value of the first byte (`91`), which does not match up with single-character unicode strings.

Fix this to work in both Python2 and Python3 by:
* explicitly specifying the characters the value is compared to as bytes
* using a 1 element slice of r.content instead of a single index to avoid getting the byte value directly

So the new check, compatible with both Python2 and Python3, is: `r.content[0:1] in [b'{', b'[']`