### PR TITLE
fix: requirements: update PyYAML to ~=5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ social-auth-app-django>=3.1.0,<4.0
 social-auth-core>=3.0.0,<4.0
 requests==2.20.0
 lxml>=2.3.2
-PyYAML>=3.10,<4.0a
+PyYAML~=5.4
 django-dont-vary-on>=1.0.0
 django-sortedm2m>=2.0.0
 django-widget-tweaks


### PR DESCRIPTION
To address CVE-2017-18342, CVE-2020-1747, and CVE-2020-14343

All related to arbitrary code execution when parsing untrusted data.

PyYAML parser is only used in `extras/servdata_consumer.py`

PyYAML renderer itself is also used in the `servdata` management command and view (when enabled).

All have been confirmed to work with the newer version.