### PR TITLE
logging: improve filtering of DisallowedHost events

### DIFF
--- a/utils/logging.py
+++ b/utils/logging.py
@@ -2,5 +2,7 @@
 def skip_disallowed_host_suspicious_operations(record):
     if record.name == 'django.security.DisallowedHost':
         return False
+    if record.name == 'django.request' and record.exc_info is not None and record.exc_info[0].__name__ == "DisallowedHost":
+        return False
     return True
 


### PR DESCRIPTION
Hi @zmousm ,

While the filter introduced in d658e30 in #15 blocks DisallowedHost events from generating an admin notification email (as these are likely to happen on a public Internet site), there has been an increasing number of emails triggered from POST requests where the `Referer` header also fails the ALLOWED_HOSTS check.

These events are sent as a generic `django.request` events with `DisallowedHost` listed as the causing exception.

Catch this case and block logging for these events as well.

Are you happy to merge this one?

Cheers,
Vlad