### PR TITLE
new: pass ATTRIB-INSTITUTION-TYPE to CAT API NEWINST call

### DIFF
--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -81,7 +81,7 @@ from django.utils.cache import (
     get_max_age, patch_response_headers, patch_vary_headers
 )
 from django_dont_vary_on.decorators import dont_vary_on
-from utils.cat_helper import CatQuery, ERTYPE_CAT_API_NAMES
+from utils.cat_helper import CatQuery
 from utils.locale import setlocale, compat_strxfrm
 
 
@@ -710,7 +710,8 @@ def cat_enroll(request):
             'NEWINST_PRIMARYADMIN': u"%s" % user.email,
             # Encode InstType in "uglify" notation
             'option[S1]': 'ATTRIB-INSTITUTION-TYPE',
-            'value[S1-0]': ERTYPE_CAT_API_NAMES[inst.ertype],
+            # CAT ADMIN API expects IdP+SP as IdPSP
+            'value[S1-0]': get_ertype_string(inst.ertype).replace("+", ""),
             }
         cq_counter=2 # start from 2 - one entry added above
         for iname in inst.org_name.all():

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -81,7 +81,7 @@ from django.utils.cache import (
     get_max_age, patch_response_headers, patch_vary_headers
 )
 from django_dont_vary_on.decorators import dont_vary_on
-from utils.cat_helper import CatQuery
+from utils.cat_helper import CatQuery, ERTYPE_CAT_API_NAMES
 from utils.locale import setlocale, compat_strxfrm
 
 
@@ -706,9 +706,13 @@ def cat_enroll(request):
 
         enroll = CatQuery(cat_api_key, cat_api_url)
         params = {
+            # Does not need to be encoded - is picked up by CatEnroll.newinst directly
             'NEWINST_PRIMARYADMIN': u"%s" % user.email,
+            # Encode InstType in "uglify" notation
+            'option[S1]': 'ATTRIB-INSTITUTION-TYPE',
+            'value[S1-0]': ERTYPE_CAT_API_NAMES[inst.ertype],
             }
-        cq_counter=1
+        cq_counter=2 # start from 2 - one entry added above
         for iname in inst.org_name.all():
             params['option[S%d]' % cq_counter] = 'general:instname'
             params['value[S%d-0]' % cq_counter] = iname.name

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -708,22 +708,26 @@ def cat_enroll(request):
         params = {
             # Does not need to be encoded - is picked up by CatEnroll.newinst directly
             'NEWINST_PRIMARYADMIN': u"%s" % user.email,
-            # Encode InstType in "uglify" notation
-            'option[S1]': 'ATTRIB-INSTITUTION-TYPE',
-            # CAT ADMIN API expects IdP+SP as IdPSP
-            'value[S1-0]': get_ertype_string(inst.ertype).replace("+", ""),
             }
-        cq_counter=2 # start from 2 - one entry added above
+        def add_option_to_params(params, cq_counter, option, value, lang=None):
+            """Add (uglified) 2/3-tuple option to parameters for CAT admin API request"""
+            params['option[S%d]' % cq_counter] = option
+            params['value[S%d-0]' % cq_counter] = value
+            if lang is not None:
+                params['value[S%d-lang]'] = lang
+            return cq_counter + 1
+        cq_counter = 1
+        cq_counter = add_option_to_params(params, cq_counter, 'ATTRIB-INSTITUTION-TYPE', get_ertype_string(
+            inst.ertype).replace("+", "")) # CAT ADMIN API expects IdP+SP as IdPSP
+        added_lang_c = False
         for iname in inst.org_name.all():
-            params['option[S%d]' % cq_counter] = 'general:instname'
-            params['value[S%d-0]' % cq_counter] = iname.name
-            params['value[S%d-lang]' % cq_counter] = iname.lang
-            cq_counter += 1
-            if iname.lang == 'en':
-                params['option[S%d]' % cq_counter] = 'general:instname'
-                params['value[S%d-0]' % cq_counter] = iname.name
-                params['value[S%d-lang]' % cq_counter] = 'C'
-                cq_counter += 1
+            langs = [iname.lang]
+            if iname.lang == 'en' and not added_lang_c:
+                langs.append('C')
+                added_lang_c = True
+            for lang in langs:
+                cq_counter = add_option_to_params(
+                    params, cq_counter, 'general:instname', iname.name, lang=lang)
         newinst = enroll.newinst(params)
         cat_url = None
         inst_uid = None

--- a/utils/cat_helper.py
+++ b/utils/cat_helper.py
@@ -3,6 +3,10 @@ from lxml import objectify
 from lxml.etree import XMLSyntaxError
 import re
 
+# Define names matching Institution ERType values exactly as expected by CAT API
+# https://github.com/GEANT/CAT/blob/master/core/IdP.php#L55-L57
+ERTYPE_CAT_API_NAMES = { 1: 'IdP', 2: 'SP', 3: 'IdPSP' }
+
 # http://code.activestate.com/recipes/135435-sort-a-string-using-numeric-order/
 def string_split_by_numbers(x):
     r = re.compile('(\d+)')

--- a/utils/cat_helper.py
+++ b/utils/cat_helper.py
@@ -3,10 +3,6 @@ from lxml import objectify
 from lxml.etree import XMLSyntaxError
 import re
 
-# Define names matching Institution ERType values exactly as expected by CAT API
-# https://github.com/GEANT/CAT/blob/master/core/IdP.php#L55-L57
-ERTYPE_CAT_API_NAMES = { 1: 'IdP', 2: 'SP', 3: 'IdPSP' }
-
 # http://code.activestate.com/recipes/135435-sort-a-string-using-numeric-order/
 def string_split_by_numbers(x):
     r = re.compile('(\d+)')


### PR DESCRIPTION
To exactly match  inst types as expected by CAT, define these in utils/cat_helper.py.

In edumanage.views.catenroll, add ATTRIB-INSTITUTION-TYPE with the correct value to params passed to CatEnroll.newinst.

As the params passed will go through deuglify, pass the param in notation expected by deuglify.