### PR TITLE
Removal of Pebduroam from DJNRO

### DIFF
--- a/accounts/migrations/0001_initial.py
+++ b/accounts/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 import django.utils.timezone
 import django.contrib.auth.models
 import django.contrib.auth.validators
-from django.utils import six
+import six
 
 
 class Migration(migrations.Migration):

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -3,8 +3,8 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib import admin
 from django.conf import settings
 from django.core import validators
-from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from six import python_2_unicode_compatible
+from django.utils.translation import gettext_lazy  as _
 from edumanage.models import Institution
 import re
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,7 +5,7 @@ from django.core.mail import send_mail
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import render
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy  as _
 from accounts.models import User
 from django.views.decorators.cache import never_cache
 from django import forms

--- a/djnro/lldict.py
+++ b/djnro/lldict.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
-from django.utils.encoding import smart_text, python_2_unicode_compatible
-
+from six import python_2_unicode_compatible
+from django.utils.encoding import smart_str
 @python_2_unicode_compatible
 class LazyLangDict(SimpleLazyObject):
     def __init__(self, *args, **kwargs):
@@ -15,6 +15,6 @@ class LazyLangDict(SimpleLazyObject):
     def __str__(self):
         if len(self):
             k, v = next(iter(self.items()))
-            return smart_text(v)
+            return smart_str(v)
         else:
             return super(LazyLangDict, self).__str__()

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -11,7 +11,7 @@ import os
 # djnro.lldict.LazyLangDict ensures that an (arbitrary) string value
 # will be returned where a dict is not expected.
 from djnro.lldict import LazyLangDict as _ld
-#from django.utils.translation import ugettext_lazy as _
+#from django.utils.translation import gettext_lazy  as _
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PROJECT_DIR = os.path.join(BASE_DIR, 'djnro')
 

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -24,7 +24,7 @@
 # ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy  as _
 import os
 from utils.edb_versioning import EduroamDatabaseVersionDef
 

--- a/djnro/templates/base.html
+++ b/djnro/templates/base.html
@@ -67,7 +67,6 @@
                     <ul class="dropdown-menu">
                           <li class="{% block closest %}{% endblock %}"><a href="{% url 'geolocate' %}" target="_blank">{% trans "Closest eduroam" %}</a></li>
                           <li class="{% block world %}{% endblock %}"><a href="{% url 'world' %}">{% trans "World eduroam" %}</a></li>
-                          <li><a href="https://apps.getpebble.com/applications/5384b2119c84af48350000c7">{% trans "pebduroam" %}</a></li>
                         <li class="{% block api %}{% endblock %}"><a href="{% url 'api' %}">{% trans "Closest point api" %}</a>
                     </ul>
                 </li>

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -503,21 +503,3 @@ If you want to use LDAP authentication, local_settings.py must be amended:
 	}
 
 
-## Pebble Watch Application (pebduroam)
-
-The closest point API allows for development of location aware-applications.
-Pebduroam is a proof-of-concept Pebble watch application that fetches the closest eduroam service location and provides walking instructions on how to reach it.
-Installing the application on your Pebble watch can be done in 2 ways:
-
-* You can install the application via the Pebble App Store: [pebduroam](https://apps.getpebble.com/applications/5384b2119c84af48350000c7)
-
-* You can get the application and contribute to its' development on [GitHub](https://github.com/leopoul/pebduroam).
-
-  * You need to have a Cloudpebble account to accomplish this.
-
-  * Once logged-in you need to select *Import - Import from github* and paste the pebduroam github repo url in the corresponding text box.
-
-  * Having configured your Pebble watch in developer mode will allow you to build and install your cloned project source directly on your watch.
-
-   **Attention: By default pebduroam uses GRNET servers for the closest point API. To switch the Pebble app to your djnro installation you need to follow the second method of installation.**
-

--- a/edumanage/decorators.py
+++ b/edumanage/decorators.py
@@ -8,7 +8,7 @@ from django import forms
 from functools import wraps
 from django.utils.decorators import available_attrs
 from django.views.decorators.cache import (never_cache, cache_page)
-from django.utils import six
+import six
 
 from accounts.models import UserProfile
 from edumanage.forms import UserProfileForm

--- a/edumanage/forms.py
+++ b/edumanage/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import (
     ugettext as _,
-    ugettext_lazy as _l,
+    gettext_lazy  as _l,
 )
 from edumanage.models import (
     URL_i18n,

--- a/edumanage/management/commands/fetch_kml.py
+++ b/edumanage/management/commands/fetch_kml.py
@@ -22,7 +22,7 @@ from django.core.management.base import BaseCommand
 import time
 from django.conf import settings
 from django.core.cache import cache
-from django.utils import six
+import six
 from xml.etree import ElementTree
 import json
 import bz2

--- a/edumanage/management/commands/parse_institution_xml.py
+++ b/edumanage/management/commands/parse_institution_xml.py
@@ -20,7 +20,7 @@
 # SOFTWARE.
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
-from django.utils import six
+import six
 from django.db.models.signals import post_save
 from edumanage.models import *
 from edumanage.views import ourPoints

--- a/edumanage/migrations/0007_edb2_data_part1.py
+++ b/edumanage/migrations/0007_edb2_data_part1.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db import migrations
 from django.db.models import OuterRef, Subquery, F, When, Case, Value
 from django.db.models.fields import BooleanField, PositiveIntegerField
-from django.utils.functional import curry
+from functools import partial as curry
 
 from . import AppAwareRunPython
 

--- a/edumanage/migrations/0008_edb2_data_part2.py
+++ b/edumanage/migrations/0008_edb2_data_part2.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 from django.db.models import OuterRef, Subquery, F
-from django.utils.functional import curry
+from functools import partial as curry
 
 from . import AppAwareRunPython
 

--- a/edumanage/migrations/__init__.py
+++ b/edumanage/migrations/__init__.py
@@ -1,5 +1,5 @@
 from django.db import migrations
-from django.utils import six
+import six
 
 # a version of django.utils.functional.curry that *appends* extra args
 def wrapper(f, *extra_args, **extra_kwargs):

--- a/edumanage/models.py
+++ b/edumanage/models.py
@@ -3,21 +3,23 @@
 from collections import namedtuple
 from functools import partial
 import uuid
-from django.utils.inspect import getargspec
+from inspect import getfullargspec
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy  as _
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import fields
-from django.utils.functional import curry
+from functools import partial as curry
 from django.utils.text import capfirst
-from django.utils import six
+import six
 from django.core import exceptions
 from django.conf import settings
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.encoding import (
-    force_text, python_2_unicode_compatible
+from six import (
+     python_2_unicode_compatible
 )
+from django.utils.encoding import force_str as force_text
+
 from sortedm2m.fields import SortedManyToManyField
 from utils.functional import cached_property
 

--- a/edumanage/signals.py
+++ b/edumanage/signals.py
@@ -6,7 +6,7 @@ from django.db.models.signals import (
 )
 from django.dispatch import receiver
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy  as _
 from edumanage.models import ServiceLoc, Coordinates
 from edumanage.views import ourPoints
 

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -31,7 +31,7 @@ from django.contrib import messages
 from django.db.models import Max
 from django.views.decorators.cache import never_cache
 from django.utils.translation import ugettext as _
-from django.utils import six
+import six
 from accounts.models import User
 from django.core.cache import cache
 from django.contrib.auth import REDIRECT_FIELD_NAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django>=1.11,<2.0
+Django>=5.0,<6.0
 argparse>=1.2.1
-django-registration==2.0.4
-django-tinymce>=2.3.0,<3.0a
+django-registration=>2.0.4
+django-tinymce>=2.3.0
 ipaddress==1.0.22
 social-auth-app-django>=3.1.0,<4.0
 social-auth-core>=3.0.0,<4.0

--- a/utils/edb_versioning.py
+++ b/utils/edb_versioning.py
@@ -3,8 +3,8 @@
 import operator
 from semantic_version import Version
 from django.conf import settings
-from django.utils import six
-from django.utils.encoding import python_2_unicode_compatible
+import six
+from six import python_2_unicode_compatible
 from django.utils.functional import SimpleLazyObject, new_method_proxy
 from .functional import partialmethod
 

--- a/utils/functional.py
+++ b/utils/functional.py
@@ -1,5 +1,5 @@
 from functools import partial
-from django.utils.inspect import getargspec
+from inspect import getfullargspec
 try:
     from functools import partialmethod
 except ImportError:

--- a/utils/locale.py
+++ b/utils/locale.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import locale
 import threading
 from contextlib import contextmanager
-from django.utils import six
+import six
 
 # http://stackoverflow.com/a/24070673
 


### PR DESCRIPTION
Hi Team, 

I noticed recently that the Pebduroam link in the services menu is dead, with the state of pebble I don't see it coming back. 

Due to this I believe it should be removed from the template and install instructions. 

Please let me know if there is a better way to raise this concern/ request.