### PR TITLE
new: edumanage/template: add link to GEANT Location codes

### DIFF
--- a/djnro/templates/edumanage/institution_edit.html
+++ b/djnro/templates/edumanage/institution_edit.html
@@ -92,7 +92,7 @@
 				<div class="controls">
 					{{ form.venue_info }}
 					{% if form.venue_info.errors %} <div class="alert-danger"> {{ form.venue_info.errors|join_with_linebreaks }} </div>
-					{% endif %} <span class="help-block"> {{ form.venue_info.help_text }}</span>
+					{% endif %} <span class="help-block"> {{ form.venue_info.help_text }} <p> {% trans 'An indicative list of assigned codes is also available at the <a href="https://wiki.geant.org/x/kgByKQ" target="_blank">Location data</a> page in the GÉANT eduroam documentation.' %}</span>
 				</div>
 			</div>
 		    {% if institution.ertype in ERTYPE_ROLES.SP %}

--- a/djnro/templates/edumanage/services_edit.html
+++ b/djnro/templates/edumanage/services_edit.html
@@ -167,7 +167,7 @@
 			<div class="controls">
 				{{ form.venue_info }}
 				{% if form.venue_info.errors %} <div class="alert-danger"> {{ form.venue_info.errors|join_with_linebreaks }} </div>
-				{% endif %} <span class="help-block"> {{ form.venue_info.help_text }}</span>
+				{% endif %} <span class="help-block"> {{ form.venue_info.help_text }} <p> {% trans 'An indicative list of assigned codes is also available at the <a href="https://wiki.geant.org/x/kgByKQ" target="_blank">Location data</a> page in the GÉANT eduroam documentation.' %}</span>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
On the Institution Edit page, add a link to wiki page maintained by GEANT listing the location codes that can be used for the Institution Type.

Make this text translatable.

Link to the page via Confluence tiny URL - which is equivalent to a page ID, but redirects to readable URL with page title.