### PR TITLE
Fix CAT URLs: overview_idp changed to overview_org, TEST URLs changed

### DIFF
--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -245,12 +245,12 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = []
 #     },
 #     'testing': {
 #         "CAT_API_KEY": "<provided API key>",
-#         "CAT_API_URL": "https://cat-test.eduroam.org/test/admin/API.php",
-#         "CAT_USER_API_URL": "https://cat-test.eduroam.org/test/user/API.php",
+#         "CAT_API_URL": "https://cat-test.eduroam.org/admin/API.php",
+#         "CAT_USER_API_URL": "https://cat-test.eduroam.org/user/API.php",
 #         "CAT_USER_API_VERSION": 2,
-#         "CAT_USER_API_LOCAL_DOWNLOADS": "https://cat-test.eduroam.org/test/",
-#         "CAT_PROFILES_URL": "https://cat-test.eduroam.org/test",
-#         "CAT_IDPMGMT_URL": "https://cat-test.eduroam.org/test/admin/overview_idp.php"
+#         "CAT_USER_API_LOCAL_DOWNLOADS": "https://cat-test.eduroam.org/",
+#         "CAT_PROFILES_URL": "https://cat-test.eduroam.org/",
+#         "CAT_IDPMGMT_URL": "https://cat-test.eduroam.org/admin/overview_idp.php"
 #     },
 # }
 

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -241,7 +241,7 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = []
 #         "CAT_USER_API_VERSION": 2,
 #         "CAT_USER_API_LOCAL_DOWNLOADS": "https://cat.eduroam.org/",
 #         "CAT_PROFILES_URL": "https://cat.eduroam.org/",
-#         "CAT_IDPMGMT_URL": "https://cat.eduroam.org/admin/overview_idp.php"
+#         "CAT_IDPMGMT_URL": "https://cat.eduroam.org/admin/overview_org.php"
 #     },
 #     'testing': {
 #         "CAT_API_KEY": "<provided API key>",
@@ -250,7 +250,7 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = []
 #         "CAT_USER_API_VERSION": 2,
 #         "CAT_USER_API_LOCAL_DOWNLOADS": "https://cat-test.eduroam.org/",
 #         "CAT_PROFILES_URL": "https://cat-test.eduroam.org/",
-#         "CAT_IDPMGMT_URL": "https://cat-test.eduroam.org/admin/overview_idp.php"
+#         "CAT_IDPMGMT_URL": "https://cat-test.eduroam.org/admin/overview_org.php"
 #     },
 # }
 


### PR DESCRIPTION

Hi @zmousm ,

I noticed the `CAT_IDPMGMT_URL` no longer worked - the URL in CAT changed from `overview_idp` to `overview_org`, so I've changed these in `local_settings.py.dist` included with  DjNRO.

I've also noticed that CAT TEST no longer prefixes all its URLs with `/test`, so I've adjusted these as well.

It's a trivial change of the provided sample (commented out) config - please let me know what you think about merging it.

Cheers,
Vlad