### PR TITLE
Remove metions of dead pebduroam project from DJNRO template

### DIFF
--- a/djnro/templates/base.html
+++ b/djnro/templates/base.html
@@ -67,7 +67,6 @@
                     <ul class="dropdown-menu">
                           <li class="{% block closest %}{% endblock %}"><a href="{% url 'geolocate' %}" target="_blank">{% trans "Closest eduroam" %}</a></li>
                           <li class="{% block world %}{% endblock %}"><a href="{% url 'world' %}">{% trans "World eduroam" %}</a></li>
-                          <li><a href="https://apps.getpebble.com/applications/5384b2119c84af48350000c7">{% trans "pebduroam" %}</a></li>
                         <li class="{% block api %}{% endblock %}"><a href="{% url 'api' %}">{% trans "Closest point api" %}</a>
                     </ul>
                 </li>

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -503,21 +503,4 @@ If you want to use LDAP authentication, local_settings.py must be amended:
 	}
 
 
-## Pebble Watch Application (pebduroam)
-
-The closest point API allows for development of location aware-applications.
-Pebduroam is a proof-of-concept Pebble watch application that fetches the closest eduroam service location and provides walking instructions on how to reach it.
-Installing the application on your Pebble watch can be done in 2 ways:
-
-* You can install the application via the Pebble App Store: [pebduroam](https://apps.getpebble.com/applications/5384b2119c84af48350000c7)
-
-* You can get the application and contribute to its' development on [GitHub](https://github.com/leopoul/pebduroam).
-
-  * You need to have a Cloudpebble account to accomplish this.
-
-  * Once logged-in you need to select *Import - Import from github* and paste the pebduroam github repo url in the corresponding text box.
-
-  * Having configured your Pebble watch in developer mode will allow you to build and install your cloned project source directly on your watch.
-
-   **Attention: By default pebduroam uses GRNET servers for the closest point API. To switch the Pebble app to your djnro installation you need to follow the second method of installation.**
 


### PR DESCRIPTION
Hi Team, 

I noticed recently that the Pebduroam link in the services menu is dead, with the state of pebble I don't see it coming back.

Due to this I believe it should be removed from the template and install instructions.

Please let me know if there is a better way to raise this concern/ request.