### PR TITLE
Fix timestamp handling in instxml and in data manipulation

### DIFF
--- a/edumanage/management/commands/parse_institution_xml.py
+++ b/edumanage/management/commands/parse_institution_xml.py
@@ -26,7 +26,11 @@ from edumanage.models import *
 from edumanage.views import ourPoints
 from edumanage.signals import (
     disable_signals,
-    DUID_RECACHE_OURPOINTS, DUID_SAVE_SERVICELOC_LATLON_CACHE
+    DUID_RECACHE_OURPOINTS, DUID_SAVE_SERVICELOC_LATLON_CACHE,
+    DUID_INSTREALM_UPDATE_INST_TS,
+    DUID_SERVICELOC_UPDATE_INST_TS,
+    DUID_INSTSERVER_UPDATE_INST_TS,
+    DUID_CONTACT_UPDATE_TS
 )
 from lxml.etree import parse
 from collections import defaultdict
@@ -772,7 +776,11 @@ for UUID. This can be disabled by using this option.''')
 
         with disable_signals(
                 (post_save,
-                 (DUID_RECACHE_OURPOINTS, DUID_SAVE_SERVICELOC_LATLON_CACHE))
+                 (DUID_RECACHE_OURPOINTS, DUID_SAVE_SERVICELOC_LATLON_CACHE,
+                     DUID_INSTREALM_UPDATE_INST_TS,
+                     DUID_SERVICELOC_UPDATE_INST_TS,
+                     DUID_INSTSERVER_UPDATE_INST_TS,
+                     DUID_CONTACT_UPDATE_TS))
         ):
             for idx, serviceloc_element in \
                 enumerate(parameters.get('location', [])):

--- a/edumanage/signals.py
+++ b/edumanage/signals.py
@@ -7,7 +7,7 @@ from django.db.models.signals import (
 from django.dispatch import receiver
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
-from edumanage.models import ServiceLoc, Coordinates
+from edumanage.models import ServiceLoc, Coordinates, RealmServer
 from edumanage.views import ourPoints
 
 class disable_signals(object): # pylint: disable=invalid-name
@@ -130,3 +130,9 @@ def sloc_coordinates_enforce_one(sender, instance, **kwargs):
                 'Only one set of coordinates per ServiceLoc is allowed'
             )}
         )
+
+# Update Realm TS whenever a RealmServer is added/changed/deleted
+@receiver((post_save, post_delete), sender=RealmServer,
+          dispatch_uid="edumanage.models.RealmServer.update_realm_ts")
+def realmserver_update_realm_ts(sender, instance, **kwargs):
+    instance.realm.save()

--- a/edumanage/signals.py
+++ b/edumanage/signals.py
@@ -148,24 +148,30 @@ def realmserver_update_realm_ts(sender, instance, **kwargs):
 # * MonLocalAuthnParam
 # * CatEnrollment
 
+DUID_INSTREALM_UPDATE_INST_TS = "edumanage.models.InstRealm.update_inst_ts"
+
 @receiver((post_save, post_delete), sender=InstRealm,
-          dispatch_uid="edumanage.models.InstRealm.update_inst_ts")
+          dispatch_uid=DUID_INSTREALM_UPDATE_INST_TS)
 def instrealm_update_inst_ts(sender, instance, **kwargs):
     try:
         instance.instid.institutiondetails.save()
     except InstitutionDetails.DoesNotExist:
         pass
 
+DUID_SERVICELOC_UPDATE_INST_TS = "edumanage.models.serviceloc.update_inst_ts"
+
 @receiver((post_save, post_delete), sender=ServiceLoc,
-          dispatch_uid="edumanage.models.serviceloc.update_inst_ts")
+          dispatch_uid=DUID_SERVICELOC_UPDATE_INST_TS)
 def serviceloc_update_inst_ts(sender, instance, **kwargs):
     try:
         instance.institutionid.institutiondetails.save()
     except InstitutionDetails.DoesNotExist:
         pass
 
+DUID_INSTSERVER_UPDATE_INST_TS = "edumanage.models.instserver.update_inst_ts"
+
 @receiver((post_save, post_delete), sender=InstServer,
-          dispatch_uid="edumanage.models.instserver.update_inst_ts")
+          dispatch_uid=DUID_INSTSERVER_UPDATE_INST_TS)
 def instserver_update_inst_ts(sender, instance, **kwargs):
     for inst in instance.instid.all():
         try:
@@ -173,10 +179,12 @@ def instserver_update_inst_ts(sender, instance, **kwargs):
         except InstitutionDetails.DoesNotExist:
             pass
 
+DUID_CONTACT_UPDATE_TS = "edumanage.models.contact.update_ts"
+
 # For Contacts (linked from Realm InstitutionDetails or ServiceLoc as ManyToManyField),
 # listen for pre_delete instead of post_delete to still see the linked objects
 @receiver((post_save, pre_delete), sender=Contact,
-          dispatch_uid="edumanage.models.contact.update_ts")
+          dispatch_uid=DUID_CONTACT_UPDATE_TS)
 def contact_update_inst_ts(sender, instance, **kwargs):
     for inst in instance.institutiondetails_set.all():
         inst.save()

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -2251,7 +2251,11 @@ def instxml(request, version):
             instUrl.text = '-'
 
         instTs = ElementTree.SubElement(instElement, "ts")
-        instTs.text = "%s" % inst.ts.isoformat()
+        instMaxTs = max( [inst.ts] +
+                [srv.ts for srv in institution.servers.all()] +
+                [sl.ts for sl in servicelocs.get(institution.id, [])]
+                )
+        instTs.text = "%s" % instMaxTs.isoformat()
         #Let's go to Institution Service Locations
 
         for serviceloc in servicelocs.get(institution.id, []):


### PR DESCRIPTION

Fix pending issues identified in #92 ( [this comment](https://github.com/grnet/djnro/pull/92#issuecomment-2172242587) ) to avoid eDB ignoring updates to Institution or Realm data because `ts` has not changed:

(1) For an Institution, where `InstServer` and `ServiceLoc` objects track their own timestamps, return institution `ts` as maximum over `ts` of institution itself and its subordinate objects.

(2) In data manipulation of subordinate objects included in the export, update `Institution` `ts` whenever a subordinate object is added, updated or deleted.  
* This also covers *removing* an InstServer* or *ServiceLoc* which would not be covered by the `max` calculation.
* Achieve this via Django signals (these are also active for manipulations done via Django admin interface).
* Generally rely on `post_save` and `post_delete` signals.
* For `Contact` objects (linked via a `ManyToManyField`), use a `pre_delete` signal instead to still see the links.
* Guard `Institution.institutiondetails` navigation with `InstitutionDetails.DoesNotExist` (in case the details object does not exist).
* Suppress the signals from `parse_institution_xml` same as other update-related signals are suppressed (to avoid too high churn updating institution timestamp).