### PR TITLE
Update django-registration for django 1.11+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.11,<2.0
 argparse>=1.2.1
-django-registration==2.0.4
+django-registration>=2.1,<2.6
 django-tinymce>=2.3.0,<3.0a
 ipaddress==1.0.22
 social-auth-app-django>=3.1.0,<4.0


### PR DESCRIPTION
In the update to Django 1.11 (PR #56), django-registration was left behind. That hasn't caused any real problems except when you run `./manage.py cleanupregistration`. Then you get an error:

```
File "/opt/djnro/.venv/lib/python3.8/site-packages/registration/management/commands/cleanupregistration.py", line 10, in <module>
    from django.core.management.base import NoArgsCommand
ImportError: cannot import name 'NoArgsCommand' from 'django.core.management.base' (/opt/djnro/.venv/lib/python3.8/site-packages/django/core/management/base.py)
```

That is a result of a deprecation in Django 1.9 that went away in 1.11. It was fixed in django-registration 2.1.

Looking at the release notes for django-registration, there are no breaking changes that would affect DjNRO [all the way up to 2.5.2](https://django-registration.readthedocs.io/en/2.5.2/upgrade.html). None of the changed functions mentioned in the notes are used in DjNRO. So, pending a larger overhaul, it seems safe to bump this up to < 2.6. My testing hasn't revealed any problems with doing this.
