### PR TITLE
Show the value of is_social_active on the UserProfile admin page

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -4,6 +4,6 @@ from django.contrib.auth.admin import UserAdmin
 
 @admin.register(UserProfile)
 class UserPrAdmin(admin.ModelAdmin):
-    list_display = ('user', 'institution')
+    list_display = ('user', 'institution', 'is_social_active')
 
 admin.site.register(User, UserAdmin)

--- a/accounts/migrations/0001_initial.py
+++ b/accounts/migrations/0001_initial.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             name='UserProfile',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('is_social_active', models.BooleanField(default=False, verbose_name="Link to institution approved")),
+                ('is_social_active', models.BooleanField(default=False, verbose_name="Approved")),
             ],
             options={
                 'permissions': (('overview', 'Can see registered user and respective institutions'),),

--- a/accounts/migrations/0001_initial.py
+++ b/accounts/migrations/0001_initial.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             name='UserProfile',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('is_social_active', models.BooleanField(default=False)),
+                ('is_social_active', models.BooleanField(default=False, verbose_name="Link to institution approved")),
             ],
             options={
                 'permissions': (('overview', 'Can see registered user and respective institutions'),),

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -36,7 +36,7 @@ patch_username_maxlen(User._meta.get_field('username'))
 class UserProfile(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     institution = models.ForeignKey(Institution, on_delete=models.CASCADE)
-    is_social_active = models.BooleanField(default=False)
+    is_social_active = models.BooleanField(default=False, verbose_name="Link to institution approved")
 
     class Meta:
         permissions = (

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -36,7 +36,7 @@ patch_username_maxlen(User._meta.get_field('username'))
 class UserProfile(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     institution = models.ForeignKey(Institution, on_delete=models.CASCADE)
-    is_social_active = models.BooleanField(default=False, verbose_name="Link to institution approved")
+    is_social_active = models.BooleanField(default=False, verbose_name="Approved")
 
     class Meta:
         permissions = (


### PR DESCRIPTION
The variable _is_social_active_ is a good indication of whether a user account has been activated. This information is useful to have when looking through user accounts. This change adds the value to an additional column in the admin portal for convenience.

<img width="2831" height="446" alt="Screenshot 2025-07-14 at 11 15 19 AM" src="https://github.com/user-attachments/assets/f2cdd91f-0dda-4eff-a076-c590f9f33cc5" />
