### PR TITLE
Update project to run on Django 5.2

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,4 +1,4 @@
-VERSION = '1.3.0'
+VERSION = '1.3.1'
 
 if __name__ == "__main__":
     print(VERSION)

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -98,6 +98,7 @@ SHIB_LOGOUT_URL = 'https://example.com/Shibboleth.sso/Logout'
 SERVER_EMAIL = "Example domain eduroam Service <noreply@example.com>"
 EMAIL_SUBJECT_PREFIX = "[eduroam] "
 ACCOUNT_ACTIVATION_DAYS = 7
+REGISTRATION_SALT = "customsaltvalue"
 NOTIFY_ADMIN_MAILS = ["mail1@example.com", "mail2@example.com"]
 
 #### CACHE BACKEND ####

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -98,7 +98,6 @@ SHIB_LOGOUT_URL = 'https://example.com/Shibboleth.sso/Logout'
 SERVER_EMAIL = "Example domain eduroam Service <noreply@example.com>"
 EMAIL_SUBJECT_PREFIX = "[eduroam] "
 ACCOUNT_ACTIVATION_DAYS = 7
-REGISTRATION_SALT = "customsaltvalue"
 NOTIFY_ADMIN_MAILS = ["mail1@example.com", "mail2@example.com"]
 
 #### CACHE BACKEND ####

--- a/djnro/local_settings.py.dist
+++ b/djnro/local_settings.py.dist
@@ -98,6 +98,7 @@ SHIB_LOGOUT_URL = 'https://example.com/Shibboleth.sso/Logout'
 SERVER_EMAIL = "Example domain eduroam Service <noreply@example.com>"
 EMAIL_SUBJECT_PREFIX = "[eduroam] "
 ACCOUNT_ACTIVATION_DAYS = 7
+REGISTRATION_SALT = "customise-this-value"
 NOTIFY_ADMIN_MAILS = ["mail1@example.com", "mail2@example.com"]
 
 #### CACHE BACKEND ####

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -463,7 +463,7 @@ EDUROAM_DATABASE_VERSIONS = {
     ),
 }
 
-REGISTRATION_SALT = "customsaltvalue"
+REGISTRATION_SALT = "customise-this-value"
 
 SENTRY = dict()
 

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -463,7 +463,7 @@ EDUROAM_DATABASE_VERSIONS = {
     ),
 }
 
-REGISTRATION_SALT = "customise-this-value"
+REGISTRATION_SALT = "registration"
 
 SENTRY = dict()
 

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -463,6 +463,8 @@ EDUROAM_DATABASE_VERSIONS = {
     ),
 }
 
+REGISTRATION_SALT = "customsaltvalue"
+
 SENTRY = dict()
 
 import _version

--- a/djnro/static/css/style.css
+++ b/djnro/static/css/style.css
@@ -139,3 +139,7 @@ footer.auth {
 input[readonly].input {
 	color: rgba(51, 51, 51, 0.5);
 }
+
+.btn-link {
+	padding-top: 15px;
+}

--- a/djnro/templates/base.html
+++ b/djnro/templates/base.html
@@ -70,9 +70,14 @@
                         <li class="{% block api %}{% endblock %}"><a href="{% url 'api' %}">{% trans "Closest point api" %}</a>
                     </ul>
                 </li>
-                {% if request.user.is_authenticated %}
-                <li><a href="{% url 'logout' %}">Logout</a></li>
-                {% endif %}
+                <li>
+                  {% if request.user.is_authenticated %}
+                  <form method="POST" action="{% url 'logout' %}">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-link">Logout</button>
+                  </form>
+                  {% endif %}
+                </li>
               </ul>
             </div><!--/.nav-collapse -->
           </div>

--- a/djnro/templates/base.html
+++ b/djnro/templates/base.html
@@ -70,14 +70,14 @@
                         <li class="{% block api %}{% endblock %}"><a href="{% url 'api' %}">{% trans "Closest point api" %}</a>
                     </ul>
                 </li>
+                {% if request.user.is_authenticated %}
                 <li>
-                  {% if request.user.is_authenticated %}
                   <form method="POST" action="{% url 'logout' %}">
                     {% csrf_token %}
                     <button type="submit" class="btn btn-link">Logout</button>
                   </form>
-                  {% endif %}
                 </li>
+                {% endif %}
               </ul>
             </div><!--/.nav-collapse -->
           </div>

--- a/djnro/templates/overview/index.html
+++ b/djnro/templates/overview/index.html
@@ -17,7 +17,10 @@
 						<a href="{% url 'overview' %}">{% trans "Overview" %}</a>
 					</li>
 					<li>
-						<a href="{% url 'logout' %}">{% trans "Logout" %}</a>
+						<form method="POST" action="{% url 'logout' %}">
+							{% csrf_token %}
+							<button type="submit" class="btn btn-link">{% trans "Logout" %}</button>
+						</form>
 					</li>
 				</ul>
 			</div><!--/.well -->

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -529,4 +529,12 @@ To fix this, edit the memcached configuration file (usually located at `/etc/mem
 ```
 This will allow DjNRO to cache files larger than one Megabyte.
 
+## Account Registration Salt (DjNRO Version 1.3.1 and Later)
 
+DjNRO version 1.3.1 updates the project from running on Django 4.2 to Django 5.2. This required updating the package `django-registration` from version 3.4 to version 5.2.1.
+
+However, a consequence of this change is that the account registration and activation flow changed between package versions. To make DjNRO work with this change, a new setting has been added to `local_settings.py`. This setting is called `REGISTRATION_SALT`.
+
+This setting is used during the creation of activation keys for new users. For more information about this setting, refer to [the django-registration documentarion](https://django-registration.readthedocs.io/en/stable/activation-workflow.html#security-considerations).
+
+Changing this setting is not *strictly* necessary, as per the django-registration documentation. However, we **STRONGLY** recommend changing the default value of this setting.

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -537,6 +537,6 @@ However, a consequence of this change is that the account registration and activ
 
 This setting is used during the creation of activation keys for new users. For more information about this setting, refer to [the django-registration documentarion](https://django-registration.readthedocs.io/en/stable/activation-workflow.html#security-considerations).
 
-This setting is defined in the file `settings.py`. If you wish to overwrite this value, you can redefine the setting in `local_settings.py`. Changing this setting is not *strictly* necessary, as per the django-registration documentation. However, we **STRONGLY** recommend changing the default value.
+While `settings.py` provides a fallback value for this setting  and changing it is not *strictly* necessary, we *strongly* recommend overriding the value in `local_settings.py` to a locally generated value.  The current version of the `local_settings.py.dist` template includes a place-holder for this value.
 
 To generate a random `REGISTRATION_SALT` value, you can use a utility such as *openssl*. A command such as `openssl rand -base64 24` is sufficient.

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -533,8 +533,10 @@ This will allow DjNRO to cache files larger than one Megabyte.
 
 DjNRO version 1.3.1 updates the project from running on Django 4.2 to Django 5.2. This required updating the package `django-registration` from version 3.4 to version 5.2.1.
 
-However, a consequence of this change is that the account registration and activation flow changed between package versions. To make DjNRO work with this change, a new setting has been added to `settings.py`. This setting is called `REGISTRATION_SALT`.
+However, a consequence of this change is that the account registration and activation flow changed between package versions. To make DjNRO work with this change, a new setting has been added called `REGISTRATION_SALT`.
 
 This setting is used during the creation of activation keys for new users. For more information about this setting, refer to [the django-registration documentarion](https://django-registration.readthedocs.io/en/stable/activation-workflow.html#security-considerations).
 
-Changing this setting is not *strictly* necessary, as per the django-registration documentation. However, we **STRONGLY** recommend changing the default value of this setting.
+This setting is defined in the file `settings.py`. If you wish to overwrite this value, you can redefine the setting in `local_settings.py`. Changing this setting is not *strictly* necessary, as per the django-registration documentation. However, we **STRONGLY** recommend changing the default value.
+
+To generate a random `REGISTRATION_SALT` value, you can use a utility such as *openssl*. A command such as `openssl rand -base64 24` is sufficient.

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -533,7 +533,7 @@ This will allow DjNRO to cache files larger than one Megabyte.
 
 DjNRO version 1.3.1 updates the project from running on Django 4.2 to Django 5.2. This required updating the package `django-registration` from version 3.4 to version 5.2.1.
 
-However, a consequence of this change is that the account registration and activation flow changed between package versions. To make DjNRO work with this change, a new setting has been added to `local_settings.py`. This setting is called `REGISTRATION_SALT`.
+However, a consequence of this change is that the account registration and activation flow changed between package versions. To make DjNRO work with this change, a new setting has been added to `settings.py`. This setting is called `REGISTRATION_SALT`.
 
 This setting is used during the creation of activation keys for new users. For more information about this setting, refer to [the django-registration documentarion](https://django-registration.readthedocs.io/en/stable/activation-workflow.html#security-considerations).
 

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -1604,14 +1604,14 @@ def user_login(request):
 @never_cache
 def user_logout(request, **kwargs):
     shib_logout_url = getattr(settings, 'SHIB_LOGOUT_URL', None)
-    if 'return' in request.GET and \
-            'action' in request.GET and \
-            request.GET.get('action') == 'logout':
-        request_data = request.GET.copy()
+    if 'return' in request.POST and \
+            'action' in request.POST and \
+            request.POST.get('action') == 'logout':
+        request_data = request.POST.copy()
         request_data[REDIRECT_FIELD_NAME] = request_data.get('return')
         del request_data['return']
         del request_data['action']
-        request.GET = request_data
+        request.POST = request_data
     elif shib_logout_url is not None and \
             request.session.get('SHIB_LOGOUT') is True:
         kwargs['next_page'] = shib_logout_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
-# Django 4.2.19 is part of the Django 4.2 LTS and will reach end of life April 2026
-Django~=4.2.19
+# Django 5.2 is an LTS release that will be supported until April 2028.
+Django~=5.2.9
 
-# These django packages are using versions that are known to work for Django 4.2
-django-registration==3.4
+# Django-related packages
+django-registration==5.2.1
 django-tinymce==4.1.0
-social-auth-app-django==5.4.3
+social-auth-app-django==5.6.0
 social-auth-core==4.5.6
 django-sortedm2m==4.0.0
 django-widget-tweaks==1.5.0
 
-# These packages are all using versions that we know work for the project as of now.
+# Other packages
 requests==2.32.4
 six==1.17.0
 lxml==5.3.1


### PR DESCRIPTION
DjNRO currently runs on Django 4.2.

As per [the Django downloads page](https://www.djangoproject.com/download/#supported-versions), this version will reach end of extended support by April this year.

These changes update the project to use Django 5.2, which will receive extended support until April 2028.

This also fixes https://github.com/REANNZ/djnro/security/dependabot/18 by updating the version of social-auth-app-django to version 5.6. Updating Django to a later version was a requirement for this update.