### PR TITLE
Fix TinyMCE initialisation

### DIFF
--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -268,7 +268,7 @@ TINYMCE_COMPRESSOR = False # not compatible with django-tinymce==4.1.0 / TinyMCE
 TINYMCE_DEFAULT_CONFIG = {
     'extended_valid_elements' :  'iframe[src|width|height|name|align]',
     'plugins': 'table link list searchreplace visualchars visualblocks code',
-    'menubar': 'edit insert view format table table',
+    'menubar': 'edit insert view format table',
     'entity_encoding': 'raw',
     'entities': '160,nbsp,173,shy,8194,ensp,8195,emsp,8201,thinsp,8204,zwnj,8205,zwj,8206,lrm,8207,rlm',
     'promotion': False,

--- a/djnro/settings.py
+++ b/djnro/settings.py
@@ -262,14 +262,16 @@ SESSION_COOKIE_AGE = 3600
 SESSION_SAVE_EVERY_REQUEST = True
 CSRF_COOKIE_AGE = 3600
 
-TINYMCE_COMPRESSOR = True
+# TinyMCE settings
+TINYMCE_COMPRESSOR = False # not compatible with django-tinymce==4.1.0 / TinyMCE 6
 
 TINYMCE_DEFAULT_CONFIG = {
     'extended_valid_elements' :  'iframe[src|width|height|name|align]',
-    'plugins': "table,paste,searchreplace",
-    'theme': "advanced",
+    'plugins': 'table link list searchreplace visualchars visualblocks code',
+    'menubar': 'edit insert view format table table',
     'entity_encoding': 'raw',
     'entities': '160,nbsp,173,shy,8194,ensp,8195,emsp,8201,thinsp,8204,zwnj,8205,zwj,8206,lrm,8207,rlm',
+    'promotion': False,
 }
 
 # to gracefully handle upgrades, a default but definitely invalid


### PR DESCRIPTION

This patch is the result of debugging an error where the flat pages content field's TinyMCE editor does not load, and the field shows raw HTML. There's an error on the JavaScript console that reads:
```
init_tinymce.js:63 Uncaught ReferenceError: tinyMCE is not defined
    at HTMLDocument.<anonymous>
```

That leads you down a rabbit hole because of a bug in TINYMCE_COMPRESSOR for the current version of django-tinymce that causes it to reference the old (TinyMCE v4) object rather than the new one. The workaround is to (hopefully temporarily) disable the compressor until it's fixed. In any event, the performance impact of this is low since the TinyMCE code is only loaded in the admin interface and then only on the flatpages.

Having resolved that, you get to the real reason for the editor failing to initialise and the following errors in the JavaScript console:
```
Failed to load theme: advanced from url themes/advanced/theme.min.js
Failed to load plugin: paste from url plugins/paste/plugin.min.js
```

That's because the original TINYMCE_DEFAULT_CONFIG in settings.py was for TinyMCE 4. However, the newer version of django-tinymce (4.1.0) ships with TinyMCE 6. This results in a configuration that includes plugins that no longer exist (paste) and a non-existent "advanced" theme.

This updates the initialisation of TinyMCE to one that's compatible with TinyMCE v6 / django-tinymce 4.1.0.