### PR TITLE
Misc minor fixes

### DIFF
--- a/djnro/templates/base.html
+++ b/djnro/templates/base.html
@@ -1,4 +1,10 @@
 {% load i18n %}
+{% if not LANGUAGE_CODE %}
+{% get_current_language as LANGUAGE_CODE %}
+{% endif %}
+{% if not LANGUAGES %}
+{% get_available_languages as LANGUAGES %}
+{% endif %}
 {% load static %}
 <!DOCTYPE html>
 <html>

--- a/edumanage/urls.py
+++ b/edumanage/urls.py
@@ -23,8 +23,8 @@ urlpatterns = [
     path("usage/realm_data.xml", edumanage.views.realmdataxml, name="realmdataxml"),
 
     # The next two lines enable views that expose private/sensitive data:
-    #url(r'^radius_serv_data', edumanage.views.servdata, name="servdata"),
-    #url(r'^admin_mail_list', edumanage.views.adminlist, name="adminlist"),
+    #path("radius_serv_data/", edumanage.views.servdata, name="servdata"),
+    #path("admin_mail_list/", edumanage.views.adminlist, name="adminlist"),
 
     path("manage/", edumanage.views.manage, name="manage"),
     path("manage/login/", edumanage.views.manage_login_front, name="manage_login_front"),

--- a/edumanage/urls.py
+++ b/edumanage/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path, re_path
 import edumanage.views
-from django.contrib.flatpages import views
 
 urlpatterns = [
     path('', edumanage.views.index, name="index"),
@@ -62,10 +61,4 @@ urlpatterns = [
     path("manage/catenroll/", edumanage.views.cat_enroll, name="catenroll"),
 
     path("overview/", edumanage.views.overview, name="overview"),
-
-    path("faq/el/", views.flatpage, {"url": "/faq/el/"}, name="faq-el"),
-    path("faq/en/", views.flatpage, {"url": "/faq/en/"}, name="faq-en"),
-    path("faq/mi/", views.flatpage, {"url": "/faq/mi/"}, name="faq-mi"),
-    path("what/el/", views.flatpage, {"url": "/what/el/"}, name="what-el"),
-    path("what/en/", views.flatpage, {"url": "/what/en/"}, name="what-en"),
 ]

--- a/edumanage/views.py
+++ b/edumanage/views.py
@@ -2609,7 +2609,7 @@ def servdata(request):
 @never_cache
 def adminlist(request):
     users = User.objects.filter(userprofile__isnull=False,
-                                registrationprofile__isnull=False)
+                                is_active=True)
     data = [
         (u.userprofile.institution.get_name(get_language()),
          u.first_name + " " + u.last_name,


### PR DESCRIPTION
A minor cleanup post previous Django updates:
* update url syntax also for commented out code
* in (unused) `adminlist` view, remove remaining reference to now removed `registrationprofile` model (and instead  filter to only include active user accounts)
* do not explicitly map flatpage URLs (covered by FlatpageFallbackMiddleware)
* fix rendering of 500 error page (which went into a death spiral because of missing LANGUAGE_CODE)

Details in individual commits.

Can you please have a look @Razorfang ?

Cheers,
Vlad