### PR TITLE
Fix two issues in Django model

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -13,7 +13,7 @@ def patch_username_maxlen(field, maxlen=255):
     field.max_length = maxlen
     # try also updating the help_text
     try:
-        help_text = field.help_text._proxy____args[0]
+        help_text = str(field.help_text)
         if help_text != None:
             field.help_text = _(re.sub("[0-9]+(?= characters)",
                                        str(maxlen),

--- a/edumanage/migrations/0001_initial.py
+++ b/edumanage/migrations/0001_initial.py
@@ -171,7 +171,7 @@ class Migration(migrations.Migration):
             name='Realm',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('country', models.CharField(max_length=5, choices=edumanage.models.get_choices_from_settings('REALM_COUNTRIES'))),
+                ('country', models.CharField(max_length=5, choices=edumanage.models.get_str_choices_from_settings('REALM_COUNTRIES'))),
                 ('stype', models.PositiveIntegerField(default=0, editable=False)),
                 ('address_street', models.CharField(max_length=32)),
                 ('address_city', models.CharField(max_length=24)),

--- a/edumanage/models.py
+++ b/edumanage/models.py
@@ -38,6 +38,12 @@ def validate_venue_info(value):
 def get_choices_from_settings(setting):
     return getattr(settings, setting, tuple())
 
+def get_str_choices_from_settings(setting):
+    """Return a set of choices with each name converted to a string.
+
+    This is needed for Django 5.2+ admin pages to avoid confusion with grouped choices."""
+    choices = get_choices_from_settings(setting)
+    return tuple([ (k, str(v)) for  k, v in choices])
 
 class MultiSelectFormField(forms.MultipleChoiceField):
     widget = forms.CheckboxSelectMultiple
@@ -928,7 +934,7 @@ class Realm(models.Model):
         unique=True,
         db_column='ROid'
     )
-    country = models.CharField(max_length=5, choices=get_choices_from_settings('REALM_COUNTRIES'))
+    country = models.CharField(max_length=5, choices=get_str_choices_from_settings('REALM_COUNTRIES'))
     stype = 0 # hard-coded (FLRS)
     stage = models.PositiveIntegerField(
         choices=PRODUCTION_STATES,


### PR DESCRIPTION
(1) Fix choices for `Realm.country` - to avoid Django 5.2+ displaying a grouped list where language version of country name become choices (and country code gets replaced with language code)

(2) Stop Django from generating spurious migrations for accounts.User model.

Details in commit messages.